### PR TITLE
Normalization layer added to converter

### DIFF
--- a/converters/keras2json.py
+++ b/converters/keras2json.py
@@ -131,6 +131,25 @@ def _get_dense_layer_parameters(h5, layer_config, n_in):
     }
     return return_dict, weights.shape[1]
 
+############### new layer
+def _normalization_parameters(h5, layer_config, n_in):
+    """Get weights (gamma), bias (beta), for normalization layer"""
+    layer_group = h5[layer_config['name']]
+    layers = _get_h5_layers(layer_group)
+    weights = layers['gamma']
+    bias = layers['beta']
+    # Do some checks
+    assert weights.shape[0] == bias.shape[0]
+    assert weights.shape[0] == n_in
+    return_dict = {
+        'weights': weights.T.flatten('C').tolist(),
+        'bias': bias.flatten('C').tolist(),
+        'architecture': 'normalization',
+    }
+    return return_dict, weights.shape[0]
+
+###########################
+
 def _get_maxout_layer_parameters(h5, layer_config, n_in):
     """Get weights, bias, and n-outputs for a maxout layer"""
     layer_group = h5[layer_config['name']]
@@ -258,6 +277,7 @@ def _activation_parameters(h5, layer_config, n_in):
 
 _layer_converters = {
     'dense': _get_dense_layer_parameters,
+    'batchnormalization': _normalization_parameters,
     'highway': _get_highway_layer_parameters,
     'maxoutdense': _get_maxout_layer_parameters,
     'lstm': _lstm_parameters,

--- a/converters/keras2json.py
+++ b/converters/keras2json.py
@@ -131,7 +131,6 @@ def _get_dense_layer_parameters(h5, layer_config, n_in):
     }
     return return_dict, weights.shape[1]
 
-############### new layer
 def _normalization_parameters(h5, layer_config, n_in):
     """Get weights (gamma), bias (beta), for normalization layer"""
     layer_group = h5[layer_config['name']]
@@ -147,8 +146,6 @@ def _normalization_parameters(h5, layer_config, n_in):
         'architecture': 'normalization',
     }
     return return_dict, weights.shape[0]
-
-###########################
 
 def _get_maxout_layer_parameters(h5, layer_config, n_in):
     """Get weights, bias, and n-outputs for a maxout layer"""

--- a/include/lwtnn/NNLayerConfig.hh
+++ b/include/lwtnn/NNLayerConfig.hh
@@ -15,7 +15,8 @@
 namespace lwt {
   enum class Activation {NONE, LINEAR, SIGMOID, RECTIFIED, SOFTMAX, TANH,
       HARD_SIGMOID};
-  enum class Architecture {NONE, DENSE, MAXOUT, HIGHWAY, LSTM, GRU, EMBEDDING};
+  enum class Architecture {NONE, DENSE, NORMALIZATION, MAXOUT, HIGHWAY, 
+      LSTM, GRU, EMBEDDING};
   // components (for LSTM, etc)
   enum class Component {
     I, O, C, F,                 // LSTM

--- a/include/lwtnn/Stack.hh
+++ b/include/lwtnn/Stack.hh
@@ -69,6 +69,7 @@ namespace lwt {
     // returns the size of the next layer
     size_t add_layers(size_t n_inputs, const LayerConfig&);
     size_t add_dense_layers(size_t n_inputs, const LayerConfig&);
+    size_t add_normalization_layers(size_t n_inputs, const LayerConfig&);
     size_t add_highway_layers(size_t n_inputs, const LayerConfig&);
     size_t add_maxout_layers(size_t n_inputs, const LayerConfig&);
     std::vector<ILayer*> _layers;
@@ -134,6 +135,26 @@ namespace lwt {
   private:
     std::vector<MatrixXd> _matrices;
     MatrixXd _bias;
+  };
+
+
+  /// Normalization layer ///
+  /// https://arxiv.org/abs/1502.03167 ///
+  class NormalizationLayer : public ILayer
+  {
+
+  public:
+    NormalizationLayer(const MatrixXd& W,const VectorXd& b);
+    virtual VectorXd compute(const VectorXd&) const;
+
+  private:
+    MatrixXd _W;
+    VectorXd _b;
+
+    int _n_outputs;
+
+    bool _return_sequences;
+
   };
 
   //http://arxiv.org/pdf/1505.00387v2.pdf
@@ -305,6 +326,7 @@ namespace lwt {
   // consistency checks
   void throw_if_not_maxout(const LayerConfig& layer);
   void throw_if_not_dense(const LayerConfig& layer);
+  void throw_if_not_normalization(const LayerConfig& layer);
 
   // LSTM component for convenience in some layers
   struct DenseComponents

--- a/include/lwtnn/Stack.hh
+++ b/include/lwtnn/Stack.hh
@@ -151,10 +151,6 @@ namespace lwt {
     MatrixXd _W;
     VectorXd _b;
 
-    int _n_outputs;
-
-    bool _return_sequences;
-
   };
 
   //http://arxiv.org/pdf/1505.00387v2.pdf

--- a/src/Stack.cxx
+++ b/src/Stack.cxx
@@ -1,5 +1,6 @@
 #include "lwtnn/Stack.hh"
 #include <Eigen/Dense>
+#include <iostream>
 
 #include <set>
 
@@ -237,7 +238,9 @@ namespace lwt {
   {
   }
   VectorXd NormalizationLayer::compute(const VectorXd& in) const {
-    return ( in * _W.cols() ) + _b ;
+    VectorXd shift = in + _b ;
+    MatrixXd _W_t = _W.transpose();
+    return _W_t.cwiseProduct(shift);
   }
 
   // highway layer

--- a/src/Stack.cxx
+++ b/src/Stack.cxx
@@ -62,6 +62,8 @@ namespace lwt {
   size_t Stack::add_layers(size_t n_inputs, const LayerConfig& layer) {
     if (layer.architecture == Architecture::DENSE) {
       return add_dense_layers(n_inputs, layer);
+    } else if (layer.architecture == Architecture::NORMALIZATION){
+      return add_normalization_layers(n_inputs, layer);
     } else if (layer.architecture == Architecture::HIGHWAY){
       return add_highway_layers(n_inputs, layer);
     } else if (layer.architecture == Architecture::MAXOUT) {
@@ -100,6 +102,27 @@ namespace lwt {
     }
 
     return n_outputs;
+  }
+
+  size_t Stack::add_normalization_layers(size_t n_inputs, const LayerConfig& layer) {
+    assert(layer.architecture == Architecture::NORMALIZATION);
+    throw_if_not_normalization(layer);
+
+    // Do some checks
+    if ( layer.weights.size() < 1 || layer.bias.size() < 1 ) {
+      std::string problem = "Either weights or bias layer size is < 1";
+      throw NNConfigurationException(problem);
+    };
+    if ( layer.weights.size() != layer.bias.size() ) {
+      std::string problem = "weights and bias layer are not equal in size!";
+      throw NNConfigurationException(problem);
+    };
+    MatrixXd m_weights = build_matrix(layer.weights, n_inputs);
+    VectorXd v_bias = build_vector(layer.bias);
+
+    _layers.push_back(
+      new NormalizationLayer(m_weights, v_bias));
+    return n_inputs;
   }
 
 
@@ -205,6 +228,16 @@ namespace lwt {
     }
     outputs += _bias;
     return outputs.colwise().maxCoeff();
+  }
+
+   // Normalization layer
+   NormalizationLayer::NormalizationLayer(const MatrixXd& W,
+                                          const VectorXd& b):
+    _W(W), _b(b)
+  {
+  }
+  VectorXd NormalizationLayer::compute(const VectorXd& in) const {
+    return ( in * _W.cols() ) + _b ;
   }
 
   // highway layer
@@ -589,6 +622,12 @@ namespace lwt {
   void throw_if_not_dense(const LayerConfig& layer) {
     if (layer.sublayers.size() > 0) {
       throw NNConfigurationException("sublayers in dense layer");
+    }
+  }
+
+  void throw_if_not_normalization(const LayerConfig& layer) {
+    if (layer.sublayers.size() > 0) {
+      throw NNConfigurationException("sublayers in normalization layer");
     }
   }
 

--- a/src/parse_json.cxx
+++ b/src/parse_json.cxx
@@ -43,6 +43,8 @@ namespace lwt {
 
       if (arch == Architecture::DENSE) {
         add_dense_info(layer, v);
+      } else if (arch == Architecture::NORMALIZATION) {
+        add_dense_info(layer, v); // re-use dense layer
       } else if (arch == Architecture::MAXOUT) {
         add_maxout_info(layer, v);
       } else if (arch == Architecture::LSTM ||
@@ -99,6 +101,7 @@ namespace {
   lwt::Architecture get_architecture(const std::string& str) {
     using namespace lwt;
     if (str == "dense") return Architecture::DENSE;
+    if (str == "normalization") return Architecture::NORMALIZATION;
     if (str == "highway") return Architecture::HIGHWAY;
     if (str == "maxout") return Architecture::MAXOUT;
     if (str == "lstm") return Architecture::LSTM;


### PR DESCRIPTION
It seems only the scaling and shifting outputs of the normalization layer is needed
when applying this in a trained NN. Therefore, weights = gamma, and
bias = beta. running mean and std may not be needed.
https://arxiv.org/pdf/1502.03167v3.pdf