### PR TITLE
get epsilon value from json file for normalization layer.

### DIFF
--- a/converters/keras2json.py
+++ b/converters/keras2json.py
@@ -144,7 +144,7 @@ def _normalization_parameters(h5, layer_config, n_in):
     assert mean.shape[0] == stddev.shape[0]
     assert gamma.shape[0] == n_in
     assert 'activation' not in layer_config
-    epsilon = 1e-05
+    epsilon = layer_config['epsilon']
     scale = gamma / np.sqrt(stddev + epsilon)
     offset = -mean+(beta*np.sqrt(stddev + epsilon)/(gamma))
     return_dict = {


### PR DESCRIPTION
This assumes that the value of epsilon does not change from 1 BN layer to the next (i.e. someone manually changing the value in each BN layer they create). Since this value is really just a fudge factor that people shouldn't be setting anyway, I doubt this will happen.