### PR TITLE
CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,8 @@ src/lwtnn-test-graph.cxx
 src/lwtnn-test-rnn.cxx
 )
 
+# Build each exectuable and link lwtnn
+# Also set it's install path when make install is called
 foreach( exec_full ${EXECUTABLES} )
     # I used a simple string replace, to cut off .cpp.
     string( REPLACE "src/" ""  execname_temp ${exec_full} )
@@ -55,13 +57,30 @@ foreach( exec_full ${EXECUTABLES} )
     add_executable( ${execname} ${exec_full} )
     # Make sure YourLib is linked to each app
     target_link_libraries( ${execname} lwtnn )
+    install(TARGETS ${execname} 
+        RUNTIME DESTINATION bin 
+    )
 endforeach( exec_full ${EXECUTABLES} )
 
+# Install path for liblwtnn.so
 install(TARGETS lwtnn 
         LIBRARY DESTINATION lib
 )
+# Install path for lwtnn headers
 install(DIRECTORY include/lwtnn
         DESTINATION include)
 
-install(DIRECTORY converters
-        DESTINATION .)
+# Install path for converter scripts
+install(
+    FILES 
+    converters/keras2json.py  
+    converters/agile2json.py
+    converters/julian2json.py
+    converters/keras_layer_converters_common.py
+    converters/keras_v1_layer_converters.py
+    converters/keras_v2_layer_converters.py
+    converters/kerasfunc2json.py
+    PERMISSIONS OWNER_EXECUTE OWNER_READ
+    DESTINATION converters
+)
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required (VERSION 3.0)
 project(lwtnn)
-set(CMAKE_BUILD_TYPE Release)
+set(GCC_COVERAGE_COMPILE_FLAGS "-O2 -Wall -fPIC -g -std=c++11 -pedantic")
+add_definitions(${GCC_COVERAGE_COMPILE_FLAGS})
 
 #Include the headers
 set( EIGEN_INC "$ENV{EIGEN_INC}" )
@@ -16,6 +17,9 @@ endif()
 include_directories ( "${EIGEN_INC}" )
 include_directories ( "${BOOST_INC}" )
 include_directories(include)
+
+set( CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin )
+set( CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib )
  
 set(SOURCES
 src/Exceptions.cxx
@@ -26,21 +30,38 @@ src/LightweightNeuralNetwork.cxx
 src/NanReplacer.cxx
 src/Stack.cxx
 src/lightweight_nn_streamers.cxx
-#src/lwtnn-benchmark-rnn.cxx
-#src/lwtnn-dump-config.cxx
-#src/lwtnn-test-arbitrary-net.cxx
-#src/lwtnn-test-graph.cxx
-#src/lwtnn-test-rnn.cxx
-src/parse_json.cxx)
+src/parse_json.cxx
+src/test_utilities.cxx
+src/test_utilities.hh)
  
 #Generate the shared library from the sources
 add_library(lwtnn SHARED ${SOURCES})
- 
-#add_executable(lwtnn-test-lightweight-graph 
-#src/lwtnn-test-lightweight-graph.cxx)
-
-#target_link_libraries(lwtnn-test-lightweight-graph ${SOURCES})
 
 
+#Executables to be built
+set(EXECUTABLES
+src/lwtnn-test-lightweight-graph.cxx
+src/lwtnn-benchmark-rnn.cxx
+src/lwtnn-dump-config.cxx
+src/lwtnn-test-arbitrary-net.cxx
+src/lwtnn-test-graph.cxx
+src/lwtnn-test-rnn.cxx
+)
 
+foreach( exec_full ${EXECUTABLES} )
+    # I used a simple string replace, to cut off .cpp.
+    string( REPLACE "src/" ""  execname_temp ${exec_full} )
+    string( REPLACE ".cxx" ""  execname ${execname_temp} )
+    add_executable( ${execname} ${exec_full} )
+    # Make sure YourLib is linked to each app
+    target_link_libraries( ${execname} lwtnn )
+endforeach( exec_full ${EXECUTABLES} )
 
+install(TARGETS lwtnn 
+        LIBRARY DESTINATION lib
+)
+install(DIRECTORY include/lwtnn
+        DESTINATION include)
+
+install(DIRECTORY converters
+        DESTINATION .)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,46 @@
+cmake_minimum_required (VERSION 3.0)
+project(lwtnn)
+set(CMAKE_BUILD_TYPE Release)
+
+#Include the headers
+set( EIGEN_INC "$ENV{EIGEN_INC}" )
+if( NOT EIGEN_INC )
+    message( FATAL_ERROR "Please point the environment variable EIGEN_INC
+    to the include directory of your eigen3 installation.")
+endif()
+set( BOOST_INC "$ENV{BOOST_INC}" )
+if( NOT BOOST_INC )
+    message( FATAL_ERROR "Please point the environment variable BOOST_INC
+    to the include directory of your Boost installation.")
+endif()
+include_directories ( "${EIGEN_INC}" )
+include_directories ( "${BOOST_INC}" )
+include_directories(include)
+ 
+set(SOURCES
+src/Exceptions.cxx
+src/Graph.cxx
+src/InputPreprocessor.cxx
+src/LightweightGraph.cxx
+src/LightweightNeuralNetwork.cxx
+src/NanReplacer.cxx
+src/Stack.cxx
+src/lightweight_nn_streamers.cxx
+#src/lwtnn-benchmark-rnn.cxx
+#src/lwtnn-dump-config.cxx
+#src/lwtnn-test-arbitrary-net.cxx
+#src/lwtnn-test-graph.cxx
+#src/lwtnn-test-rnn.cxx
+src/parse_json.cxx)
+ 
+#Generate the shared library from the sources
+add_library(lwtnn SHARED ${SOURCES})
+ 
+#add_executable(lwtnn-test-lightweight-graph 
+#src/lwtnn-test-lightweight-graph.cxx)
+
+#target_link_libraries(lwtnn-test-lightweight-graph ${SOURCES})
+
+
+
+


### PR DESCRIPTION
This is to get a handle on how to compile from scratch when I put in Athena and have to use cmake.
It's probably not a bad idea to have generally, but I'll leave it up to you whether or not you want this.

Something quite interesting, there are a loooot of warnings on lxplus (stupid indentation warnings etc. because of Eigen.), but none when building on Mac. Maybe we don't wan't -Wall flag set? not sure why it only displays them with cmake build and not normal make build.

Anyways, some instructions:

**Setting up the correct env in lxplus**
```
lsetup root 
localSetupSFT releases/LCG_88/eigen/3.2.9
localSetupBoost  boost-1.60.0-python2.7-x86_64-slc6-gcc49
export EIGEN_INC=/cvmfs/sft.cern.ch/lcg/releases/LCG_88/eigen/3.2.9/x86_64-slc6-gcc49-opt/include/eigen3
export BOOST_INC=export BOOST_INC=/cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase/x86_64/boost/boost-1.60.0-python2.7-x86_64-slc6-gcc49/boost-1.60.0-python2.7-x86_64-slc6-gcc49/include
lsetup "cmake 3.6.0"
```
Setting up Root helps get cmtconfig tag and just helps with matching eigen automatically.
Paths need to be set explicitly for some reason. And you need a newer version of cmake.

**External to lxplus**
Just have a newer cmake, and point EIGEN_INC and BOOST_INC to respective folders (will complain and fail if can't find it.)
On my mac it's something like `/usr/local/include`.

**Compiling**
```
checkout lwtnn
mkdir build install; cd build
cmake -DCMAKE_INSTALL_PREFIX=../install ../lwtnn
make -j4
make install
```
Then add the headers to libraries to appropriate paths.

Give it a try, should work

