### PR TITLE
Cmake tweaks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,13 +7,13 @@ add_definitions(${GCC_COVERAGE_COMPILE_FLAGS})
 # We search the standard places. If they don't exist, 
 # the user needs to supply the paths.
 # i.e. cmake -DEIGEN_INC=<> -DBOOST_INC=<>
-set(EIGEN_INC "/usr/local/include/eigen3" CACHE PATH "Path to Eigen headers")
+set(EIGEN_INC "/usr/include/eigen3" CACHE PATH "Path to Eigen headers")
 if( NOT EXISTS ${EIGEN_INC} )
     message( FATAL_ERROR "Please add the command -DEIGEN_INC=<path/to/eigen/headers>
     to the cmake configuration.")
 endif()
 
-set(BOOST_INC "/usr/local/include" CACHE PATH "Path to Boost headers")
+set(BOOST_INC "/usr/include" CACHE PATH "Path to Boost headers")
 if( NOT EXISTS ${BOOST_INC}/boost )
     message( FATAL_ERROR "Please add the command -DBOOST_INC=<path/to/boost/headers>
     to the cmake configuration.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,19 +1,24 @@
 cmake_minimum_required (VERSION 3.0)
 project(lwtnn)
-set(GCC_COVERAGE_COMPILE_FLAGS "-O2 -Wall -fPIC -g -std=c++11 -pedantic")
+set(GCC_COVERAGE_COMPILE_FLAGS "-O2 -fPIC -g -std=c++11")
 add_definitions(${GCC_COVERAGE_COMPILE_FLAGS})
 
 #Include the headers
-set( EIGEN_INC "$ENV{EIGEN_INC}" )
-if( NOT EIGEN_INC )
-    message( FATAL_ERROR "Please point the environment variable EIGEN_INC
-    to the include directory of your eigen3 installation.")
+# We search the standard places. If they don't exist, 
+# the user needs to supply the paths.
+# i.e. cmake -DEIGEN_INC=<> -DBOOST_INC=<>
+set(EIGEN_INC "/usr/local/include/eigen3" CACHE PATH "Path to Eigen headers")
+if( NOT EXISTS ${EIGEN_INC} )
+    message( FATAL_ERROR "Please add the command -DEIGEN_INC=<path/to/eigen/headers>
+    to the cmake configuration.")
 endif()
-set( BOOST_INC "$ENV{BOOST_INC}" )
-if( NOT BOOST_INC )
-    message( FATAL_ERROR "Please point the environment variable BOOST_INC
-    to the include directory of your Boost installation.")
+
+set(BOOST_INC "/usr/local/include" CACHE PATH "Path to Boost headers")
+if( NOT EXISTS ${BOOST_INC}/boost )
+    message( FATAL_ERROR "Please add the command -DBOOST_INC=<path/to/boost/headers>
+    to the cmake configuration.")
 endif()
+
 include_directories ( "${EIGEN_INC}" )
 include_directories ( "${BOOST_INC}" )
 include_directories(include)
@@ -48,14 +53,14 @@ src/lwtnn-test-graph.cxx
 src/lwtnn-test-rnn.cxx
 )
 
-# Build each exectuable and link lwtnn
+# Build each executable and link lwtnn
 # Also set it's install path when make install is called
 foreach( exec_full ${EXECUTABLES} )
-    # I used a simple string replace, to cut off .cpp.
+    # Use a simple string to remove .cxx and src/.
     string( REPLACE "src/" ""  execname_temp ${exec_full} )
     string( REPLACE ".cxx" ""  execname ${execname_temp} )
     add_executable( ${execname} ${exec_full} )
-    # Make sure YourLib is linked to each app
+    # Link lwtnn for each executable
     target_link_libraries( ${execname} lwtnn )
     install(TARGETS ${execname} 
         RUNTIME DESTINATION bin 


### PR DESCRIPTION
Change the way in which boost and eigen are found. Now by default they are looked for in /usr/local/include. If not found, it fails and set the paths manually.

I.e. to use this on lxplus, you don't even need to setup anything fancy, but rather just point it to the headers.

```
lsetup "gcc 620_x86_64_slc6"
lsetup "cmake 3.6.0"
cmake -DEIGEN_INC=/cvmfs/sft.cern.ch/lcg/releases/LCG_88/eigen/3.2.9/x86_64-slc6-gcc49-opt/include/eigen3 -DBOOST_INC=/cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase/x86_64/boost/boost-1.60.0-python2.7-x86_64-slc6-gcc49/boost-1.60.0-python2.7-x86_64-slc6-gcc49/include ../lwtnn
```
 
This is needed so that I can make use of this CMakeLists.txt file for the Athena build, see here: https://gitlab.cern.ch/jwsmith/atlasexternals/tree/out_source_lwtnn

I also removed some warnings.