### PR TITLE
Required version of boost no less than 1.54

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,7 @@ if( BUILTIN_BOOST )
    message( STATUS "Using a privately downloaded Boost version for the build" )
 else()
    # Look for Boost on the build system.
-   find_package( Boost 1.60.0 REQUIRED )
+   find_package( Boost 1.54.0 REQUIRED )
 endif()
 
 # Figure out what to do with Eigen.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,7 @@ if( BUILTIN_BOOST )
    message( STATUS "Using a privately downloaded Boost version for the build" )
 else()
    # Look for Boost on the build system.
-   find_package( Boost REQUIRED )
+   find_package( Boost 1.60.0 REQUIRED )
 endif()
 
 # Figure out what to do with Eigen.


### PR DESCRIPTION
(Avoid property tree errors. I'm not actually sure which version
this was added, but this is safe. )