### PR TITLE
clang-9.0 fix, master branch (2017.12.08.)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,9 @@ endif()
 # Set the project's name and version.
 project( lwtnn VERSION 2.4 )
 
+# Enable using CTest in the project.
+include( CTest )
+
 # Set up the "C++ version" to use.
 set( CMAKE_CXX_STANDARD_REQUIRED 11 CACHE STRING
    "Minimum C++ standard required for the build" )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,6 +184,22 @@ install( FILES
    PERMISSIONS OWNER_EXECUTE OWNER_READ
    DESTINATION converters )
 
+# Helper macro for building the project's unit tests.
+macro( lwtnn_add_test name )
+   # Build the unit-test executable:
+   add_executable( ${name} ${ARGN} )
+   target_link_libraries( ${name} lwtnn-stat )
+   set_target_properties( ${name} PROPERTIES
+      RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/test-bin" )
+   # Set up the test itself:
+   add_test( NAME ${name}_ctest
+      COMMAND ${CMAKE_BINARY_DIR}/test-bin/${name}
+      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/test-bin )
+endmacro( lwtnn_add_test )
+
+# Set up the test(s) of the project.
+lwtnn_add_test( test-nn-streamers tests/test-nn-streamers.cxx )
+
 # Install the CMake description of the project.
 install( EXPORT lwtnnTargets
    FILE lwtnnConfig-targets.cmake

--- a/include/lwtnn/lightweight_nn_streamers.hh
+++ b/include/lwtnn/lightweight_nn_streamers.hh
@@ -6,9 +6,9 @@
 namespace lwt {
   struct LayerConfig;
   struct Input;
-}
 
-std::ostream& operator<<(std::ostream&, const lwt::LayerConfig&);
-std::ostream& operator<<(std::ostream&, const lwt::Input&);
+  std::ostream& operator<<(std::ostream&, const LayerConfig&);
+  std::ostream& operator<<(std::ostream&, const Input&);
+}
 
 #endif

--- a/src/lightweight_nn_streamers.cxx
+++ b/src/lightweight_nn_streamers.cxx
@@ -5,7 +5,7 @@
 #include <string>
 #include <stdexcept>
 
-namespace {
+namespace lwt {
   std::ostream& operator<<(std::ostream& out,
 			   const std::vector<double>& vec) {
     size_t nentry = vec.size();
@@ -61,7 +61,7 @@ namespace {
 }
 
 
-std::ostream& operator<<(std::ostream& out, const lwt::LayerConfig& cfg){
+std::ostream& lwt::operator<<(std::ostream& out, const lwt::LayerConfig& cfg){
   using namespace lwt;
   out << "architecture: " << cfg.architecture << "\n";
   out << "activation: " << activation_as_string(cfg.activation) << "\n";
@@ -95,7 +95,7 @@ std::ostream& operator<<(std::ostream& out, const lwt::LayerConfig& cfg){
   }
   return out;
 }
-std::ostream& operator<<(std::ostream& out, const lwt::Input& input) {
+std::ostream& lwt::operator<<(std::ostream& out, const lwt::Input& input) {
   out << input.name << " -- offset: " << input.offset << " scale: "
       << input.scale;
   return out;

--- a/tests/test-nn-streamers.cxx
+++ b/tests/test-nn-streamers.cxx
@@ -1,0 +1,53 @@
+/// @file tests/test-nn-streamers.cxx
+///
+/// Test that the std stream operators work correctly.
+///
+
+// System include(s):
+#include <iostream>
+#include <sstream>
+
+/// Class exercising the custom streamers when using a non-std output stream
+///
+/// This is needed, because clang treats output operators a bit more
+/// conservatively than GCC, which only shows up in such a setup.
+///
+class TestStream : public std::ostringstream {
+
+public:
+   /// Inherit the base class's constructors
+   using std::ostringstream::ostringstream;
+
+   /// Output operator
+   template< class T >
+   TestStream& operator<< ( const T& arg ) {
+      ( * ( std::ostringstream* ) this ) << arg;
+      return *this;
+   }
+
+}; // class TestStream
+
+// LWTNN include(s):
+#include "lwtnn/NNLayerConfig.hh"
+#include "lwtnn/lightweight_network_config.hh"
+#include "lwtnn/lightweight_nn_streamers.hh"
+
+int main() {
+
+   // Print a dummy lwt::Input object:
+   const lwt::Input dummy1{ "Dummy", 0.0, 1.0 };
+   TestStream stream1;
+   stream1 << "lwt::Input: " << dummy1;
+   std::cout << stream1.str() << std::endl;
+
+   // Print a dumm lwt::LayerConfig object:
+   const lwt::LayerConfig dummy2{ { 1.0, 2.0 }, { 1.0, 2.0 }, { 1.0, 2.0 },
+                                  lwt::Activation::NONE, lwt::Activation::NONE,
+                                  {}, {}, {}, lwt::Architecture::NONE };
+   TestStream stream2;
+   stream2 << "lwt::LayerConfig: " << dummy2;
+   std::cout << stream2.str() << std::endl;
+
+   // Return gracefully:
+   return 0;
+}

--- a/tests/travis-build-cmake.sh
+++ b/tests/travis-build-cmake.sh
@@ -19,8 +19,10 @@ ARGS=''
 if [[ ${MINIMAL+x} ]]; then
     ARGS="-DBUILTIN_BOOST=TRUE -DBUILTIN_EIGEN=TRUE"
 fi
+export MAKEFLAGS="-j`nproc` -l`nproc`"
 cmake ${ARGS} ..
-make -j 4
+cmake --build .
+ctest --output-on-failure -j`nproc`
 popd
 
 if [[ -d bin ]]; then


### PR DESCRIPTION
Hi,

While trying to build the latest ATLAS analysis software release against lwtnn on macOS, I encountered the following build failure:

```
[ 89%] Building CXX object Reconstruction/Jet/BoostedJetTaggers/CMakeFiles/BoostedJetTaggersLib.dir/Root/HbbTaggerDNN.cxx.o
In file included from /Users/krasznaa/ATLAS/sw/ab/athena/Reconstruction/Jet/BoostedJetTaggers/Root/HbbTaggerDNN.cxx:5:
In file included from /Users/krasznaa/ATLAS/sw/ab/athena/Reconstruction/Jet/BoostedJetTaggers/BoostedJetTaggers/HbbTaggerDNN.h:10:
In file included from /Users/krasznaa/ATLAS/sw/ab/athena/Control/AthToolSupport/AsgTools/AsgTools/AsgTool.h:13:
In file included from /Users/krasznaa/ATLAS/sw/ab/athena/Control/AthToolSupport/AsgTools/AsgTools/AsgMessaging.h:11:
/Users/krasznaa/ATLAS/sw/ab/athena/Control/AthToolSupport/AsgTools/AsgTools/MsgStream.h:56:42: error: call to function 'operator<<' that is neither visible in the template definition nor found by argument-dependent lookup
      ( * ( std::ostringstream* ) this ) << arg;
                                         ^
/Users/krasznaa/ATLAS/sw/ab/athena/Reconstruction/Jet/BoostedJetTaggers/Root/HbbTaggerDNN.cxx:99:26: note: in instantiation of function template specialization 'MsgStream::operator<<<lwt::Input>' requested here
      ATH_MSG_DEBUG("  " << input << (dummy ? " <-- DUMMY": "") );
                         ^
/Users/krasznaa/ATLAS/sw/ab/build/install/AnalysisBaseExternals/21.2.12/InstallArea/x86_64-mac1013-clang90-opt/include/lwtnn/lightweight_nn_streamers.hh:12:15: note: 'operator<<' should be declared prior to the call site or in namespace 'lwt'
std::ostream& operator<<(std::ostream&, const lwt::Input&);
              ^

1 error generated.
make[2]: *** [Reconstruction/Jet/BoostedJetTaggers/CMakeFiles/BoostedJetTaggersLib.dir/Root/HbbTaggerDNN.cxx.o] Error 1
```

Now, I'll be setting up a "fix" for the ATLAS code itself that will be avoiding this issue by only modifying that code, but I thought it could also be a good idea to make lwtnn more robust against users trying to use the output operators in an "unfortunate" way like we did in the ATLAS code.

This update adds both a test that recreates the issue that I encountered in the ATLAS code, and also updates the output operator definitions/implementations to work un such an awkward setup as well.

Cheers,
      Attila