### PR TITLE
Update Swish to support Keras-contrib implementation

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -29,6 +29,10 @@
             "name": "Daniel Edison Marley",
             "affiliation": "Texas A&M University",
             "orcid": "0000-0002-6290-078X"
+        },
+        {
+            "name": "Aishik Ghosh",
+            "orcid": "0000-0003-0819-1553"
         }
     ]
 }

--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ supported for Keras 1.0.8 and higher.
 | Softmax       | Yes          |
 | ELU           | Yes          |
 | LeakyReLU     | Yes          |
+| Swish         | Yes          |
 
 The converter scripts can be found in `converters/`. Run them with
 `-h` for more information.

--- a/converters/keras_v2_layer_converters.py
+++ b/converters/keras_v2_layer_converters.py
@@ -129,14 +129,11 @@ def _alpha_activation_func(activation_name):
 def _trainable_alpha_activation_function(activation_name, alpha_parameter_name='alpha'):
     def func(h5, layer_config, n_in, layer_type):
         """Store single trainable activation parameter"""
-        layer_group = h5[layer_config['name']]
-        layers = _get_h5_layers(layer_group)
-        alpha = layers[alpha_parameter_name+BACKEND_SUFFIX]
         pars = {
             'weights':[], 'bias':[],'architecture':'dense',
             'activation':{
                 'function': activation_name,
-                'alpha': alpha.flatten('C').tolist()[0],
+                'alpha': layer_config[alpha_parameter_name],
 
             }
         }

--- a/scripts/CustomLayers.py
+++ b/scripts/CustomLayers.py
@@ -1,28 +1,48 @@
-from keras.layers import Layer
 from keras import backend as K
-from keras.layers import initializers, InputSpec
+from keras.layers import Layer
 
+#Trainable  Swish activation implementation from https://github.com/keras-team/keras-contrib/blob/master/keras_contrib/layers/advanced_activations/swish.py
 class Swish(Layer):
+    """ Swish (Ramachandranet al., 2017)
+    # Input shape
+        Arbitrary. Use the keyword argument `input_shape`
+        (tuple of integers, does not include the samples axis)
+        when using this layer as the first layer in a model.
+    # Output shape
+        Same shape as the input.
+    # Arguments
+        beta: float >= 0. Scaling factor
+            if set to 1 and trainable set to False (default),
+            Swish equals the SiLU activation (Elfwing et al., 2017)
+        trainable: whether to learn the scaling factor during training or not
+    # References
+        - [Searching for Activation Functions](https://arxiv.org/abs/1710.05941)
+        - [Sigmoid-weighted linear units for neural network function
+           approximation in reinforcement learning](https://arxiv.org/abs/1702.03118)
     """
-    Swish activation function with a trainable parameter referred to as 'beta' in https://arxiv.org/abs/1710.05941"""
-    def __init__(self, trainable_beta = True, beta_initializer = 'ones', **kwargs):
+
+    def __init__(self, beta=1.0, trainable=False, **kwargs):
         super(Swish, self).__init__(**kwargs)
         self.supports_masking = True
-        self.trainable = trainable_beta
-        self.beta_initializer = initializers.get(beta_initializer)
-        self.__name__ = 'swish'
-        
-    def build(self, input_shape):
-        self.beta = self.add_weight(shape=[1], name='beta', 
-                                    initializer=self.beta_initializer)
-        self.input_spec = InputSpec(ndim=len(input_shape))
-        self.built = True
+        self.beta = beta
+        self.trainable = trainable
 
-    def call(self, inputs):
-        return inputs * K.sigmoid(self.beta * inputs)
+    def build(self, input_shape):
+        self.scaling_factor = K.variable(self.beta,
+                                         dtype=K.floatx(),
+                                         name='scaling_factor')
+        if self.trainable:
+            self._trainable_weights.append(self.scaling_factor)
+        super(Swish, self).build(input_shape)
+
+    def call(self, inputs, mask=None):
+        return inputs * K.sigmoid(self.scaling_factor * inputs)
 
     def get_config(self):
-        config = {'trainable_beta': self.trainable, 
-                  'beta_initializer': initializers.serialize(self.beta_initializer)}
+        config = {'beta': self.get_weights()[0] if self.trainable else self.beta,
+                  'trainable': self.trainable}
         base_config = super(Swish, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
+
+    def compute_output_shape(self, input_shape):
+        return input_shape


### PR DESCRIPTION
New swish implementation : [Keras-contrib](https://github.com/keras-team/keras-contrib/blob/master/keras_contrib/layers/advanced_activations/swish.py).

Models trained in the old swish implementation can be easily translated to the new one within keras. So LWTNN doesn't need to continue supporting the old version. The C++ side is unchanged, changes only at the converter side.

Choosing _not_ to make `Keras-contrib` a dependency, so the swish implementation is copied into `CustomLayers.py`. It will _not_ be automatically updated with an update in `Keras-contrib`.

Solves https://github.com/lwtnn/lwtnn/issues/87.