### PR TITLE
Fixed compiler warnings and README typo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ endif()
 message( STATUS "Using build type: ${CMAKE_BUILD_TYPE}" )
 
 # Set the warning flag(s) to use.
-set( CMAKE_CXX_FLAGS "-Wall -pedantic -Wextra -Wcomment -Wunused-value -Wsuggest-override" )
+set( CMAKE_CXX_FLAGS "-Wall -pedantic -Wextra -Wcomment -Wunused-value" )
 
 # Turn off the usage of RPATH completely:
 set( CMAKE_SKIP_RPATH ON )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ include( CTest )
 # Set up the "C++ version" to use.
 set( CMAKE_CXX_STANDARD_REQUIRED 11 CACHE STRING
    "Minimum C++ standard required for the build" )
-set( CMAKE_CXX_STANDARD 17 CACHE STRING
+set( CMAKE_CXX_STANDARD 11 CACHE STRING
    "C++ standard to use for the build" )
 set( CMAKE_CXX_EXTENSIONS FALSE CACHE BOOL
    "(Dis)allow using compiler extensions" )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ endif()
 message( STATUS "Using build type: ${CMAKE_BUILD_TYPE}" )
 
 # Set the warning flag(s) to use.
-set( CMAKE_CXX_FLAGS "-Wall -pedantic -Wextra -Wunused-value -Wsuggest-override" )
+set( CMAKE_CXX_FLAGS "-Wall -pedantic -Wextra -Wcomment -Wunused-value -Wsuggest-override" )
 
 # Turn off the usage of RPATH completely:
 set( CMAKE_SKIP_RPATH ON )
@@ -121,9 +121,9 @@ set( lib_sources src/Exceptions.cxx src/Graph.cxx src/InputPreprocessor.cxx
 # Build the shared library.
 add_library( lwtnn SHARED ${lib_headers} ${lib_sources} )
 target_include_directories( lwtnn
-   SYSTEM PUBLIC ${EIGEN3_INCLUDE_DIR}
+   PUBLIC ${EIGEN3_INCLUDE_DIR}
    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>
-   SYSTEM PRIVATE ${Boost_INCLUDE_DIRS} )
+   PRIVATE ${Boost_INCLUDE_DIRS} )
 set_property( TARGET lwtnn
    PROPERTY PUBLIC_HEADER ${lib_headers} )
 if( BUILTIN_BOOST )
@@ -136,9 +136,9 @@ endif()
 # Build the static library.
 add_library( lwtnn-stat ${lib_headers} ${lib_sources} )
 target_include_directories( lwtnn-stat
-   SYSTEM PUBLIC ${EIGEN3_INCLUDE_DIR}
+   PUBLIC ${EIGEN3_INCLUDE_DIR}
    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>
-   SYSTEM PRIVATE ${Boost_INCLUDE_DIRS} )
+   PRIVATE ${Boost_INCLUDE_DIRS} )
 set_property( TARGET lwtnn-stat
    PROPERTY PUBLIC_HEADER ${lib_headers} )
 if( BUILTIN_BOOST )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ include( CTest )
 # Set up the "C++ version" to use.
 set( CMAKE_CXX_STANDARD_REQUIRED 11 CACHE STRING
    "Minimum C++ standard required for the build" )
-set( CMAKE_CXX_STANDARD 11 CACHE STRING
+set( CMAKE_CXX_STANDARD 17 CACHE STRING
    "C++ standard to use for the build" )
 set( CMAKE_CXX_EXTENSIONS FALSE CACHE BOOL
    "(Dis)allow using compiler extensions" )
@@ -29,7 +29,7 @@ endif()
 message( STATUS "Using build type: ${CMAKE_BUILD_TYPE}" )
 
 # Set the warning flag(s) to use.
-set( CMAKE_CXX_FLAGS "-Wall -pedantic" )
+set( CMAKE_CXX_FLAGS "-Wall -pedantic -Wextra -Wunused-value -Wsuggest-override" )
 
 # Turn off the usage of RPATH completely:
 set( CMAKE_SKIP_RPATH ON )
@@ -121,9 +121,9 @@ set( lib_sources src/Exceptions.cxx src/Graph.cxx src/InputPreprocessor.cxx
 # Build the shared library.
 add_library( lwtnn SHARED ${lib_headers} ${lib_sources} )
 target_include_directories( lwtnn
-   PUBLIC ${EIGEN3_INCLUDE_DIR}
+   SYSTEM PUBLIC ${EIGEN3_INCLUDE_DIR}
    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>
-   PRIVATE ${Boost_INCLUDE_DIRS} )
+   SYSTEM PRIVATE ${Boost_INCLUDE_DIRS} )
 set_property( TARGET lwtnn
    PROPERTY PUBLIC_HEADER ${lib_headers} )
 if( BUILTIN_BOOST )
@@ -136,9 +136,9 @@ endif()
 # Build the static library.
 add_library( lwtnn-stat ${lib_headers} ${lib_sources} )
 target_include_directories( lwtnn-stat
-   PUBLIC ${EIGEN3_INCLUDE_DIR}
+   SYSTEM PUBLIC ${EIGEN3_INCLUDE_DIR}
    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>
-   PRIVATE ${Boost_INCLUDE_DIRS} )
+   SYSTEM PRIVATE ${Boost_INCLUDE_DIRS} )
 set_property( TARGET lwtnn-stat
    PROPERTY PUBLIC_HEADER ${lib_headers} )
 if( BUILTIN_BOOST )
@@ -161,7 +161,7 @@ macro( lwtnn_add_executable name )
    add_executable( ${name} src/${name}.cxx )
    # Set its properties.
    target_link_libraries( ${name} lwtnn-stat )
-   target_include_directories( ${name} PRIVATE ${Boost_INCLUDE_DIRS} )
+   target_include_directories( ${name} SYSTEM PRIVATE ${Boost_INCLUDE_DIRS} )
    # Install it.
    install( TARGETS ${name}
       EXPORT lwtnnTargets

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ If you have CMake, you can build with _no_ other dependencies:
 
 ```bash
 mkdir build
+cd build
 cmake -DBUILTIN_BOOST=true -DBUILTIN_EIGEN=true ..
 make -j 4
 ```

--- a/include/lwtnn/Graph.hh
+++ b/include/lwtnn/Graph.hh
@@ -29,8 +29,8 @@ namespace lwt {
   {
   public:
     InputNode(size_t index, size_t n_outputs);
-    virtual VectorXd compute(const ISource&) const;
-    virtual size_t n_outputs() const;
+    virtual VectorXd compute(const ISource&) const override;
+    virtual size_t n_outputs() const override;
   private:
     size_t m_index;
     size_t m_n_outputs;
@@ -40,8 +40,8 @@ namespace lwt {
   {
   public:
     FeedForwardNode(const Stack*, const INode* source);
-    virtual VectorXd compute(const ISource&) const;
-    virtual size_t n_outputs() const;
+    virtual VectorXd compute(const ISource&) const override;
+    virtual size_t n_outputs() const override;
   private:
     const Stack* m_stack;
     const INode* m_source;
@@ -51,8 +51,8 @@ namespace lwt {
   {
   public:
     ConcatenateNode(const std::vector<const INode*>&);
-    virtual VectorXd compute(const ISource&) const;
-    virtual size_t n_outputs() const;
+    virtual VectorXd compute(const ISource&) const override;
+    virtual size_t n_outputs() const override;
   private:
     std::vector<const INode*> m_sources;
     size_t m_n_outputs;
@@ -71,8 +71,8 @@ namespace lwt {
   {
   public:
     InputSequenceNode(size_t index, size_t n_outputs);
-    virtual MatrixXd scan(const ISource&) const;
-    virtual size_t n_outputs() const;
+    virtual MatrixXd scan(const ISource&) const override;
+    virtual size_t n_outputs() const override;
   private:
     size_t m_index;
     size_t m_n_outputs;
@@ -82,9 +82,9 @@ namespace lwt {
   {
   public:
     SequenceNode(const RecurrentStack*, const ISequenceNode* source);
-    virtual MatrixXd scan(const ISource&) const;
-    virtual VectorXd compute(const ISource&) const;
-    virtual size_t n_outputs() const;
+    virtual MatrixXd scan(const ISource&) const override;
+    virtual VectorXd compute(const ISource&) const override;
+    virtual size_t n_outputs() const override;
   private:
     const RecurrentStack* m_stack;
     const ISequenceNode* m_source;
@@ -94,8 +94,8 @@ namespace lwt {
   {
   public:
     TimeDistributedNode(const Stack*, const ISequenceNode* source);
-    virtual MatrixXd scan(const ISource&) const;
-    virtual size_t n_outputs() const;
+    virtual MatrixXd scan(const ISource&) const override;
+    virtual size_t n_outputs() const override;
   private:
     const Stack* m_stack;
     const ISequenceNode* m_source;

--- a/include/lwtnn/LightweightGraph.hh
+++ b/include/lwtnn/LightweightGraph.hh
@@ -1,46 +1,46 @@
 #ifndef LIGHTWEIGHT_GRAPH_HH
 #define LIGHTWEIGHT_GRAPH_HH
 
-// Lightweight Graph
-//
-// The lightweightGraph class is a more flexible version of the
-// LightweightNeuralNetwork class. This flexibility comes from the
-// ability to read from multiple inputs, merge them, and then expose
-// multiple outputs.
-//
-// For example, a conventional feed-forward network may be structured
-// as follows:
-//
-//  I  <-- simple input vector
-//  |
-//  D  <-- dense feed-forward layer
-//  |
-//  O  <-- output activation function
-//
-// A graph is more flexible, allowing structures like the following:
-//
-//  I_s  <-- sequential input
-//   |
-//  GRU   I_v  <-- simple input vector
-//     \ /
-//      M  <-- merge layer
-//      |
-//      D  <-- dense layer
-//     / \
-//   D2   D3
-//    |   |
-//    |   O_c  <-- multiclass output (softmax activation)
-//    |
-//   O_r  <-- regression output (linnear output)
-//
-// i.e. a graph can combine any number of sequential and "standard"
-// rank-1 inputs, and can use the same internal features to infer many
-// different attributes from the input pattern.
-//
-// Like the LightweightNeuralNetwork, it contains no Eigen code: it
-// only serves as a high-level wrapper to convert std::map objects to
-// Eigen objects and Eigen objects back to std::maps. For the
-// underlying implementation, see Graph.hh.
+/* Lightweight Graph
+
+ The lightweightGraph class is a more flexible version of the
+ LightweightNeuralNetwork class. This flexibility comes from the
+ ability to read from multiple inputs, merge them, and then expose
+ multiple outputs.
+
+ For example, a conventional feed-forward network may be structured
+ as follows:
+
+  I  <-- simple input vector
+  |
+  D  <-- dense feed-forward layer
+  |
+  O  <-- output activation function
+
+ A graph is more flexible, allowing structures like the following:
+
+  I_s  <-- sequential input
+   |
+  GRU   I_v  <-- simple input vector
+     \ /
+      M  <-- merge layer
+      |
+      D  <-- dense layer
+     / \
+   D2   D3
+    |   |
+    |   O_c  <-- multiclass output (softmax activation)
+    |
+   O_r  <-- regression output (linnear output)
+
+ i.e. a graph can combine any number of sequential and "standard"
+ rank-1 inputs, and can use the same internal features to infer many
+ different attributes from the input pattern.
+
+ Like the LightweightNeuralNetwork, it contains no Eigen code: it
+ only serves as a high-level wrapper to convert std::map objects to
+ Eigen objects and Eigen objects back to std::maps. For the
+ underlying implementation, see Graph.hh. */
 
 #include "lightweight_network_config.hh"
 

--- a/include/lwtnn/Source.hh
+++ b/include/lwtnn/Source.hh
@@ -13,6 +13,7 @@ namespace lwt {
   class ISource
   {
   public:
+    virtual ~ISource() = default;
     virtual VectorXd at(size_t index) const = 0;
     virtual MatrixXd matrix_at(size_t index) const = 0;
   };
@@ -21,8 +22,8 @@ namespace lwt {
   {
   public:
     VectorSource(std::vector<VectorXd>&&, std::vector<MatrixXd>&& = {});
-    virtual VectorXd at(size_t index) const;
-    virtual MatrixXd matrix_at(size_t index) const;
+    virtual VectorXd at(size_t index) const override;
+    virtual MatrixXd matrix_at(size_t index) const override;
   private:
     std::vector<VectorXd> m_inputs;
     std::vector<MatrixXd> m_matrix_inputs;
@@ -33,8 +34,8 @@ namespace lwt {
   public:
     DummySource(const std::vector<size_t>& input_sizes,
                 const std::vector<std::pair<size_t, size_t> >& = {});
-    virtual VectorXd at(size_t index) const;
-    virtual MatrixXd matrix_at(size_t index) const;
+    virtual VectorXd at(size_t index) const override;
+    virtual MatrixXd matrix_at(size_t index) const override;
   private:
     std::vector<size_t> m_sizes;
     std::vector<std::pair<size_t, size_t> > m_matrix_sizes;

--- a/include/lwtnn/Stack.hh
+++ b/include/lwtnn/Stack.hh
@@ -80,14 +80,14 @@ namespace lwt {
   class DummyLayer: public ILayer
   {
   public:
-    virtual VectorXd compute(const VectorXd&) const;
+    virtual VectorXd compute(const VectorXd&) const override;
   };
 
   class UnaryActivationLayer: public ILayer
   {
   public:
     UnaryActivationLayer(ActivationConfig);
-    virtual VectorXd compute(const VectorXd&) const;
+    virtual VectorXd compute(const VectorXd&) const override;
   private:
     std::function<double(double)> m_func;
   };
@@ -95,7 +95,7 @@ namespace lwt {
   class SoftmaxLayer: public ILayer
   {
   public:
-    virtual VectorXd compute(const VectorXd&) const;
+    virtual VectorXd compute(const VectorXd&) const override;
   };
 
   class BiasLayer: public ILayer
@@ -103,7 +103,7 @@ namespace lwt {
   public:
     BiasLayer(const VectorXd& bias);
     BiasLayer(const std::vector<double>& bias);
-    virtual VectorXd compute(const VectorXd&) const;
+    virtual VectorXd compute(const VectorXd&) const override;
   private:
     VectorXd m_bias;
   };
@@ -112,7 +112,7 @@ namespace lwt {
   {
   public:
     MatrixLayer(const MatrixXd& matrix);
-    virtual VectorXd compute(const VectorXd&) const;
+    virtual VectorXd compute(const VectorXd&) const override;
   private:
     MatrixXd m_matrix;
   };
@@ -122,7 +122,7 @@ namespace lwt {
   public:
     typedef std::pair<MatrixXd, VectorXd> InitUnit;
     MaxoutLayer(const std::vector<InitUnit>& maxout_tensor);
-    virtual VectorXd compute(const VectorXd&) const;
+    virtual VectorXd compute(const VectorXd&) const override;
   private:
     std::vector<MatrixXd> m_matrices;
     MatrixXd m_bias;
@@ -136,7 +136,7 @@ namespace lwt {
 
   public:
     NormalizationLayer(const VectorXd& W,const VectorXd& b);
-    virtual VectorXd compute(const VectorXd&) const;
+    virtual VectorXd compute(const VectorXd&) const override;
 
   private:
     VectorXd _W;
@@ -153,7 +153,7 @@ namespace lwt {
                  const MatrixXd& W_carry,
                  const VectorXd& b_carry,
                  ActivationConfig activation);
-    virtual VectorXd compute(const VectorXd&) const;
+    virtual VectorXd compute(const VectorXd&) const override;
   private:
     MatrixXd m_w_t;
     VectorXd m_b_t;
@@ -215,7 +215,7 @@ namespace lwt {
   public:
     EmbeddingLayer(int var_row_index, MatrixXd W);
     virtual ~EmbeddingLayer() {};
-    virtual MatrixXd scan( const MatrixXd&) const;
+    virtual MatrixXd scan( const MatrixXd&) const override;
 
   private:
     int m_var_row_index;
@@ -235,7 +235,7 @@ namespace lwt {
               MatrixXd W_c, MatrixXd U_c, VectorXd b_c);
 
     virtual ~LSTMLayer() {};
-    virtual MatrixXd scan( const MatrixXd&) const;
+    virtual MatrixXd scan( const MatrixXd&) const override;
     void step( const VectorXd& input, LSTMState& ) const;
 
   private:
@@ -273,7 +273,7 @@ namespace lwt {
              MatrixXd W_h, MatrixXd U_h, VectorXd b_h);
 
     virtual ~GRULayer() {};
-    virtual MatrixXd scan( const MatrixXd&) const;
+    virtual MatrixXd scan( const MatrixXd&) const override;
     void step( const VectorXd& input, GRUState& ) const;
 
   private:

--- a/src/LightweightGraph.cxx
+++ b/src/LightweightGraph.cxx
@@ -21,8 +21,8 @@ namespace {
   public:
     LazySource(const NodeMap&, const SeqNodeMap&,
                const Preprocs&, const VecPreprocs&);
-    virtual VectorXd at(size_t index) const;
-    virtual MatrixXd matrix_at(size_t index) const;
+    virtual VectorXd at(size_t index) const override;
+    virtual MatrixXd matrix_at(size_t index) const override;
   private:
     const NodeMap& m_nodes;
     const SeqNodeMap& m_seqs;

--- a/src/Stack.cxx
+++ b/src/Stack.cxx
@@ -16,7 +16,8 @@ namespace lwt {
   // dummy construction routine
   Stack::Stack() {
     m_layers.push_back(new DummyLayer);
-    m_layers.push_back(new UnaryActivationLayer({Activation::SIGMOID}));
+    m_layers.push_back(new UnaryActivationLayer({ Activation::SIGMOID, 0.0 }));
+
     m_layers.push_back(new BiasLayer(std::vector<double>{1, 1, 1, 1}));
     MatrixXd mat(4, 4);
     mat <<


### PR DESCRIPTION
- Marked overriding methods as 'override'
- Added more compiler warning options
- Added default virtual destructor for ISource base class (otherwise a warning is generated)
- Fixed missing initializer warning for ActivationConfig in Stack.cxx by setting alpha to zero for initialization
- ~Set CXX standard to 17, but 11 is still minimum required~
- Muted compiler warnings coming from Eigen and Boost as they cannot be fixed by code in this project (See CMakeLists.txt)
- Fixed typo in README.md