### PR TITLE
Add C++17 standard to the travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ env:
   matrix:
     - BUILD=make
     - BUILD=./tests/travis-build-cmake.sh
+    - STANDARD=17 BUILD=./tests/travis-build-cmake.sh
 
 matrix:
   include:

--- a/tests/travis-build-cmake.sh
+++ b/tests/travis-build-cmake.sh
@@ -15,9 +15,9 @@ mkdir build
 
 pushd .
 cd build
-ARGS=''
+ARGS="-DCMAKE_CXX_STANDARD=${STANDARD-11}"
 if [[ ${MINIMAL+x} ]]; then
-    ARGS="-DBUILTIN_BOOST=TRUE -DBUILTIN_EIGEN=TRUE"
+    ARGS+=" -DBUILTIN_BOOST=TRUE -DBUILTIN_EIGEN=TRUE"
 fi
 export MAKEFLAGS="-j`nproc` -l`nproc`"
 cmake ${ARGS} ..


### PR DESCRIPTION
This is following up on @VukanJ's merge request to silence warnings and clean things up for C++17. We agreed to stick to C++11 by default since the README says it's supported, but standard is getting pretty old.