### PR TITLE
Add sum layer for deep sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,12 +182,14 @@ Keras sequential and functional models:
 | Embedding       | sorta        | [issue][ghie] |
 | Concatenate     |  no          |  yes          |
 | TimeDistributed |  no          |  yes          |
+| [Sum][deepset]  |  no          |  yes          |
 
 **Note 1:** Normalization layers (i.e. Batch Normalization) are only
 supported for Keras 1.0.8 and higher.
 
 [ghie]: https://github.com/lwtnn/lwtnn/issues/39
 [ghkeras2]: https://github.com/lwtnn/lwtnn/issues/40
+[deepset]: https://arxiv.org/abs/1703.06114
 
 #### Supported Activation Functions ####
 

--- a/converters/keras_layer_converters_common.py
+++ b/converters/keras_layer_converters_common.py
@@ -16,6 +16,7 @@ _activation_map = {
     'linear': 'linear',
     'softmax': 'softmax',
     'tanh': 'tanh',
+    # 'abs': 'rectified', #TODO: add this one
     'hard_sigmoid': 'hard_sigmoid',
     # these are more advanced activation functions which include an
     # alpha parameter. Keras sometimes saves them without this

--- a/converters/kerasfunc2json.py
+++ b/converters/kerasfunc2json.py
@@ -249,6 +249,10 @@ def _build_layer(output_layers, node_key, h5, node_dict, layer_dict):
     else:
         assert len(node.sources) == 1, "in {}".format(node.layer_type)
 
+    if node.layer_type == 'sum':
+        node.n_outputs = node.sources[0].n_outputs
+        return
+
     # if this layer is already defined, just add the node count and
     # continue
     if node.name in layer_dict:
@@ -296,6 +300,7 @@ _node_type_map = {
     'activation': 'feed_forward',
     'lstm': 'sequence',
     'gru': 'sequence',
+    'sum': 'sum',
     'timedistributed': 'time_distributed',
     'softmax': 'feed_forward',
     'leakyrelu': 'feed_forward',

--- a/include/lwtnn/Graph.hh
+++ b/include/lwtnn/Graph.hh
@@ -100,6 +100,15 @@ namespace lwt {
     const Stack* m_stack;
     const ISequenceNode* m_source;
   };
+  class SumNode: public INode
+  {
+  public:
+    SumNode(const ISequenceNode* source);
+    virtual VectorXd compute(const ISource&) const override;
+    virtual size_t n_outputs() const override;
+  private:
+    const ISequenceNode* m_source;
+  };
 
   // Graph class, owns the nodes
   class Graph

--- a/include/lwtnn/NNLayerConfig.hh
+++ b/include/lwtnn/NNLayerConfig.hh
@@ -59,8 +59,9 @@ namespace lwt {
   // graph node configuration
   struct NodeConfig
   {
-    enum class Type { INPUT, INPUT_SEQUENCE, FEED_FORWARD,
-        CONCATENATE, SEQUENCE, TIME_DISTRIBUTED};
+    enum class Type {
+      INPUT, INPUT_SEQUENCE, FEED_FORWARD, CONCATENATE, SEQUENCE,
+      TIME_DISTRIBUTED, SUM };
     Type type;
     std::vector<size_t> sources;
     int index;                  // input node size, or layer number

--- a/scripts/CustomLayers.py
+++ b/scripts/CustomLayers.py
@@ -26,3 +26,30 @@ class Swish(Layer):
                   'beta_initializer': initializers.serialize(self.beta_initializer)}
         base_config = super(Swish, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
+
+
+class Sum(Layer):
+    """Simple sum layer.
+
+    This could theoretically be provided by a lambda function as well,
+    but it's provided here to encourage a consistent nameing
+    convention.
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.supports_masking = True
+
+    def build(self, input_shape):
+        pass
+
+    def call(self, x, mask=None):
+        if mask is not None:
+            x = x * K.cast(mask, K.dtype(x))[:,:,None]
+        return K.sum(x, axis=1)
+
+    def compute_output_shape(self, input_shape):
+        return input_shape[0], input_shape[2]
+
+    def compute_mask(self, inputs, mask):
+        return None

--- a/scripts/lwtnn-test-keras-functional.py
+++ b/scripts/lwtnn-test-keras-functional.py
@@ -11,9 +11,9 @@ from argparse import ArgumentParser, RawDescriptionHelpFormatter
 from numpy import linspace
 import numpy as np
 import json
-from CustomLayers import Swish
+from CustomLayers import Swish, Sum
 from keras.utils.generic_utils import get_custom_objects
-get_custom_objects().update({'Swish': Swish})
+get_custom_objects().update({'Swish': Swish, 'Sum': Sum})
 
 def _get_args():
     parser = ArgumentParser(
@@ -39,10 +39,30 @@ def run():
         inputs = json.loads(''.join(variables_file.readlines()))
 
     full_test_pattern = []
-    for in_node, in_spec in zip(model.inputs, inputs['inputs']):
-        n_inputs = in_node.shape[1]
-        assert n_inputs == len(in_spec['variables'])
-        test_pattern = linspace(-1,1,n_inputs)[None,:]
+    vec_input_iterator = iter(inputs['inputs'])
+    seq_input_iterator = iter(inputs['input_sequences'])
+    for in_node in model.inputs:
+        print(in_node.shape)
+        if len(in_node.shape) == 2:
+            in_spec = next(vec_input_iterator)
+            n_inputs = in_node.shape[1]
+            test_pattern = linspace(-1,1,n_inputs)[None,:]
+        elif len(in_node.shape) == 3:
+            in_spec = next(seq_input_iterator)
+            n_inputs = in_node.shape[2]
+            input_vec = linspace(-1,1,n_inputs)[None,:]
+            seq_vec = linspace(-1, 1, 20)[:,None]
+            test_pattern = (input_vec * seq_vec)[None,...]
+        else:
+            raise RuntimeError(
+                "not sure what to do with input sequence lentgh {}".format(
+                    len(in_node.shape)))
+        if n_inputs != len(in_spec['variables']):
+            var_names = [v['name'] for v in in_spec['variables']]
+            raise RuntimeError(
+                "need {} inputs for variables: {}".format(
+                    n_inputs, ', '.join(var_names)))
+
         full_test_pattern.append(test_pattern)
 
     outputs = model.predict(full_test_pattern)

--- a/src/Graph.cxx
+++ b/src/Graph.cxx
@@ -405,6 +405,9 @@ namespace lwt {
       }
       m_nodes[iii] = new ConcatenateNode(in_nodes);
     } else if (node.type == NodeConfig::Type::SUM) {
+      if (node.sources.size() != 1) {
+        throw NNConfigurationException("Sum node needs exactly 1 source");
+      }
       m_nodes[iii] = new SumNode(m_seq_nodes.at(node.sources.at(0)));
     } else {
       throw NNConfigurationException("unknown node type");

--- a/src/Graph.cxx
+++ b/src/Graph.cxx
@@ -185,6 +185,18 @@ namespace lwt {
   size_t TimeDistributedNode::n_outputs() const {
     return m_stack->n_outputs();
   }
+
+  SumNode::SumNode(const ISequenceNode* source):
+    m_source(source)
+  {
+  }
+  VectorXd SumNode::compute(const ISource& source) const {
+    return m_source->scan(source).rowwise().sum();
+  }
+  size_t SumNode::n_outputs() const {
+    return m_source->n_outputs();
+  }
+
 }
 
 namespace {
@@ -392,6 +404,8 @@ namespace lwt {
         in_nodes.push_back(m_nodes.at(source_node));
       }
       m_nodes[iii] = new ConcatenateNode(in_nodes);
+    } else if (node.type == NodeConfig::Type::SUM) {
+      m_nodes[iii] = new SumNode(m_seq_nodes.at(node.sources.at(0)));
     } else {
       throw NNConfigurationException("unknown node type");
     }

--- a/src/parse_json.cxx
+++ b/src/parse_json.cxx
@@ -106,6 +106,8 @@ namespace {
     return cfg;
   }
 
+  const std::set<NodeConfig::Type> layerless_nodes {
+    NodeConfig::Type::CONCATENATE, NodeConfig::Type::SUM };
   NodeConfig get_node(const ptree::value_type& v) {
     NodeConfig cfg;
 
@@ -124,7 +126,7 @@ namespace {
     } else if (cfg.type == Type::FEED_FORWARD || cfg.type == Type::SEQUENCE ||
                cfg.type == Type::TIME_DISTRIBUTED) {
       cfg.index = v.second.get<int>("layer_index");
-    } else if (cfg.type == Type::CONCATENATE){
+    } else if (layerless_nodes.count(cfg.type)){
       cfg.index = -1;
     } else {
       throw std::logic_error("unknown node type");
@@ -151,6 +153,7 @@ namespace {
     if (type == "input_sequence") return Type::INPUT_SEQUENCE;
     if (type == "concatenate") return Type::CONCATENATE;
     if (type == "time_distributed") return Type::TIME_DISTRIBUTED;
+    if (type == "sum") return Type::SUM;
     throw std::logic_error("no node type '" + type + "'");
   }
 

--- a/src/parse_json.cxx
+++ b/src/parse_json.cxx
@@ -5,6 +5,7 @@
 #include <cassert>
 #include <string>
 #include <cmath> // for NAN
+#include <set>
 
 namespace {
   using namespace boost::property_tree;


### PR DESCRIPTION
Added a sum layer to support deep set architectures. This layer doesn't
currently exist in Keras, so a Keras implementation was added to
scripts/CustomLayers.

Also add support for sequence inputs in lwtnn-test-keras-functional.