### PR TITLE
Fix bug in sequence conversion for from Keras 2.2

### DIFF
--- a/converters/keras2json.py
+++ b/converters/keras2json.py
@@ -102,6 +102,12 @@ def _get_args():
 def _get_layers(network, inputs, h5):
     layers = []
     in_layers = network['config']
+
+    # at some point the keras format must have changed or something,
+    # the layers seem to be nested more deeply than before in 2.2
+    if 'layers' in in_layers:
+        in_layers = in_layers['layers']
+
     n_out = len(inputs['inputs'])
 
     # Determine which layer version we should use


### PR DESCRIPTION
At some point it seems that Keras started storing sequence models with the layers nested more deeply, with the structure

```
{
    "class_name": "Sequential", "config": {
        "name": "sequential_1",
        "layers": [...]
    }
}
```

this broke the `keras2json.py` converter because it expected `config`
to be a list of layers.