### PR TITLE
Bump ubnutu and python versions in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: trusty
+dist: bionic
 language: python
 
 notifications:
@@ -44,7 +44,7 @@ addons:
 
 # python dependencies
 python:
-  - "3.4"
+  - "3.8"
 install:
   - pip install h5py
   - pip install pyyaml


### PR DESCRIPTION
The CI builds started failing because the python version was so old. Bumped
python to 3.8, ubuntu to bionic.