### PR TITLE
Allow 'Functional' class models to be converted

### DIFF
--- a/converters/kerasfunc2json.py
+++ b/converters/kerasfunc2json.py
@@ -80,7 +80,7 @@ def _resolve_inheriting_types(nodes):
                 node['type'] = 'feed_forward'
 
 def _check_version(arch):
-    if arch["class_name"] != "Model":
+    if arch["class_name"] not in {"Model", "Functional"}:
         sys.exit("this is not a graph, try using keras2json")
     global BACKEND
     if 'backend' not in arch:


### PR DESCRIPTION
Apparently newer version of keras have renamed the 'Model' class to
'Functional'. Nothing else seems different, so for now we'll just relax the
requirement on the class_name.