### PR TITLE
Remove Keras from network splitter

### DIFF
--- a/scripts/lwtnn-split-keras-network.py
+++ b/scripts/lwtnn-split-keras-network.py
@@ -17,11 +17,16 @@ def get_args():
 
 def run():
     args = get_args()
-    import keras
-    m = keras.models.load_model(args.model)
-    m.save_weights(args.weight_file_name)
-    with open(args.architecture_file_name,'w') as arch:
-        arch.write(m.to_json(indent=2))
+    from h5py import File
+    import json
+    m = File(args.model,'r')
+    with File(args.weight_file_name,'w') as w:
+        for name, wt in w.items():
+            w.copy(wt, name)
+
+    arch = json.loads(m.attrs['model_config'])
+    with open(args.architecture_file_name,'w') as arch_file:
+        arch_file.write(json.dumps(arch,indent=2))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Keras isn't as stable as h5py and json. This commit removes the keras dependency from the network splitting function.