### PR TITLE
Generic cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,10 +124,10 @@ set( lib_headers
    include/lwtnn/NNLayerConfig.hh
    include/lwtnn/NanReplacer.hh
    include/lwtnn/lightweight_network_config.hh
-   include/lwtnn/lightweight_nn_streamers.hh 
+   include/lwtnn/lightweight_nn_streamers.hh
    include/lwtnn/parse_json.hh )
 # Source files for the shared/static library.
-set( lib_sources 
+set( lib_sources
    src/Exceptions.cxx
    src/LightweightNeuralNetwork.cxx
    src/LightweightGraph.cxx

--- a/include/InputPreprocessor.hh
+++ b/include/InputPreprocessor.hh
@@ -1,0 +1,11 @@
+#ifndef LWTNN_INPUT_PREPROCESSOR_HH
+#define LWTNN_INPUT_PREPROCESSOR_HH
+
+#include "lwtnn/generic/InputPreprocessor.hh"
+
+namespace lwt {
+  using InputPreprocessor = generic::InputPreprocessor<double>;
+  using InputVectorPreprocessor = generic::InputVectorPreprocessor<double>;
+}
+
+#endif

--- a/include/lwtnn/Graph.hh
+++ b/include/lwtnn/Graph.hh
@@ -1,0 +1,23 @@
+#ifndef LWTNN_GRAPH_HH
+#define LWTNN_GRAPH_HH
+
+#include "lwtnn/generic/Graph.hh"
+#include "lwtnn/Source.hh"
+
+namespace lwt {
+
+  using INode = generic::INode<double>;
+  using FeedForwardNode = generic::FeedForwardNode<double>;
+  using InputNode = generic::InputNode<double>;
+  using ConcatenateNode = generic::ConcatenateNode<double>;
+  using ISequenceNode = generic::ISequenceNode<double>;
+  using InputSequenceNode = generic::InputSequenceNode<double>;
+  using SequenceNode = generic::SequenceNode<double>;
+  using TimeDistributedNode = generic::TimeDistributedNode<double>;
+
+  using Graph = generic::Graph<double>;
+
+}
+
+
+#endif

--- a/include/lwtnn/LightweightGraph.hh
+++ b/include/lwtnn/LightweightGraph.hh
@@ -47,7 +47,7 @@
 #include "lwtnn/lightweight_network_config.hh"
 
 namespace lwt {
-    
+
   namespace generic {
     template<typename T> class LightweightGraph;
   }
@@ -57,7 +57,7 @@ namespace lwt {
   typedef std::map<std::string, double> ValueMap;
   // The "VectorMap" is for sequence inputs
   typedef std::map<std::string, std::vector<double> > VectorMap;
-  
+
 
   // Graph class
   class LightweightGraph
@@ -96,7 +96,7 @@ namespace lwt {
   private:
     std::unique_ptr<generic::LightweightGraph<double>> m_impl;
   };
-  
+
 } // namespace lwt
 
 #endif

--- a/include/lwtnn/LightweightNeuralNetwork.hh
+++ b/include/lwtnn/LightweightNeuralNetwork.hh
@@ -28,7 +28,7 @@ namespace lwt {
   typedef std::map<std::string, double> ValueMap;
   typedef std::vector<std::pair<std::string, double> > ValueVector;
   typedef std::map<std::string, std::vector<double> > VectorMap;
-  
+
   // ______________________________________________________________________
   // high-level wrappers
 
@@ -36,7 +36,7 @@ namespace lwt {
     template<typename T> class LightweightNeuralNetwork;
     template<typename T> class LightweightRNN;
   }
-  
+
   // feed-forward variant
   class LightweightNeuralNetwork
   {
@@ -44,9 +44,9 @@ namespace lwt {
     LightweightNeuralNetwork(const std::vector<Input>& inputs,
                              const std::vector<LayerConfig>& layers,
                              const std::vector<std::string>& outputs);
-    
+
     ~LightweightNeuralNetwork();
-    
+
     // disable copying until we need it...
     LightweightNeuralNetwork(LightweightNeuralNetwork&) = delete;
     LightweightNeuralNetwork& operator=(LightweightNeuralNetwork&) = delete;
@@ -59,7 +59,7 @@ namespace lwt {
   private:
     std::unique_ptr<generic::LightweightNeuralNetwork<double>> m_impl;
   };
-  
+
   // recurrent version
   class LightweightRNN
   {
@@ -67,9 +67,9 @@ namespace lwt {
     LightweightRNN(const std::vector<Input>& inputs,
                    const std::vector<LayerConfig>& layers,
                    const std::vector<std::string>& outputs);
-    
+
     ~LightweightRNN();
-    
+
     LightweightRNN(LightweightRNN&) = delete;
     LightweightRNN& operator=(LightweightRNN&) = delete;
 

--- a/include/lwtnn/Source.hh
+++ b/include/lwtnn/Source.hh
@@ -1,0 +1,14 @@
+#ifndef LWTNN_SOURCE_HH
+#define LWTNN_SOURCE_HH
+
+#include "lwtnn/generic/Source.hh"
+
+namespace lwt {
+
+  using ISource = generic::ISource<double>;
+  using VectorSource = generic::VectorSource<double>;
+  using DummySource = generic::DummySource<double>;
+
+}
+
+#endif

--- a/include/lwtnn/Stack.hh
+++ b/include/lwtnn/Stack.hh
@@ -7,7 +7,7 @@ namespace lwt
 {
   // double typedef for feed-forward stack
   using Stack = generic::Stack<double>;
-  
+
   // double typedefs for feed-forward layers
   using ILayer = generic::ILayer<double>;
   using DummyLayer = generic::DummyLayer<double>;
@@ -18,35 +18,35 @@ namespace lwt
   using MaxoutLayer = generic::MaxoutLayer<double>;
   using NormalizationLayer = generic::NormalizationLayer<double>;
   using HighwayLayer = generic::HighwayLayer<double>;
-  
+
   // double typedefs for recurrent stack
   using RecurrentStack = generic::RecurrentStack<double>;
   using ReductionStack = generic::ReductionStack<double>;
-  
+
   // double typedefs for recurrent layesr
   using IRecurrentLayer = generic::IRecurrentLayer<double>;
   using EmbeddingLayer = generic::EmbeddingLayer<double>;
   using LSTMLayer = generic::LSTMLayer<double>;
   using GRULayer = generic::GRULayer<double>;
   using DenseComponents = generic::DenseComponents<double>;
-  
+
   // double typedefs for activation functions
   using ELU = generic::ELU<double>;
   using LeakyReLU = generic::LeakyReLU<double>;
   using Swish = generic::Swish<double>;
-  
+
   double nn_sigmoid( double x );
   double nn_hard_sigmoid( double x );
   double nn_tanh( double x );
   double nn_relu( double x );
-  
+
   // double typedefs for utility functions
   MatrixX<double> build_matrix(const std::vector<double>& weights, size_t n_inputs);
   VectorX<double> build_vector(const std::vector<double>& bias);
-  
+
   DenseComponents get_component(const lwt::LayerConfig& layer, size_t n_in);
   std::function<double(double)> get_activation(lwt::ActivationConfig);
-  
+
 }
 
 #endif

--- a/include/lwtnn/generic/Graph.hh
+++ b/include/lwtnn/generic/Graph.hh
@@ -11,11 +11,11 @@
 
 namespace lwt {
 namespace generic {
-    
+
   // Forward declaretions
   template<typename T>
   class Stack;
-  
+
   template<typename T>
   class RecurrentStack;
 
@@ -99,7 +99,7 @@ namespace generic {
     const RecurrentStack<T>* m_stack;
     const ISequenceNode<T>* m_source;
   };
-  
+
   template<typename T>
   class TimeDistributedNode: public ISequenceNode<T>
   {
@@ -111,7 +111,7 @@ namespace generic {
     const Stack<T>* m_stack;
     const ISequenceNode<T>* m_source;
   };
-  
+
   template<typename T>
   class SumNode: public INode<T>
   {
@@ -152,9 +152,9 @@ namespace generic {
     // At some point maybe also convolutional nodes, but we'd have to
     // have a use case for that first.
   };
-  
+
 } // namespace generic
-  
+
   using INode = generic::INode<double>;
   using FeedForwardNode = generic::FeedForwardNode<double>;
   using InputNode = generic::InputNode<double>;
@@ -163,9 +163,9 @@ namespace generic {
   using InputSequenceNode = generic::InputSequenceNode<double>;
   using SequenceNode = generic::SequenceNode<double>;
   using TimeDistributedNode = generic::TimeDistributedNode<double>;
-  
+
   using Graph = generic::Graph<double>;
-  
+
 } // namespace lwt
 
 #include "Graph.tcc"

--- a/include/lwtnn/generic/Graph.hh
+++ b/include/lwtnn/generic/Graph.hh
@@ -155,17 +155,6 @@ namespace generic {
 
 } // namespace generic
 
-  using INode = generic::INode<double>;
-  using FeedForwardNode = generic::FeedForwardNode<double>;
-  using InputNode = generic::InputNode<double>;
-  using ConcatenateNode = generic::ConcatenateNode<double>;
-  using ISequenceNode = generic::ISequenceNode<double>;
-  using InputSequenceNode = generic::InputSequenceNode<double>;
-  using SequenceNode = generic::SequenceNode<double>;
-  using TimeDistributedNode = generic::TimeDistributedNode<double>;
-
-  using Graph = generic::Graph<double>;
-
 } // namespace lwt
 
 #include "Graph.tcc"

--- a/include/lwtnn/generic/Graph.tcc
+++ b/include/lwtnn/generic/Graph.tcc
@@ -19,7 +19,7 @@ namespace generic {
     m_matrix_inputs(std::move(mm))
   {
   }
-  
+
   template<typename T>
   VectorX<T> VectorSource<T>::at(size_t index) const {
     if (index >= m_inputs.size()) {
@@ -28,7 +28,7 @@ namespace generic {
     }
     return m_inputs.at(index);
   }
-  
+
   template<typename T>
   MatrixX<T> VectorSource<T>::matrix_at(size_t index) const {
     if (index >= m_matrix_inputs.size()) {
@@ -37,7 +37,7 @@ namespace generic {
     }
     return m_matrix_inputs.at(index);
   }
-  
+
   template<typename T>
   DummySource<T>::DummySource(const std::vector<size_t>& input_sizes,
                                 const std::vector<std::pair<size_t,size_t> >& ma):
@@ -45,7 +45,7 @@ namespace generic {
     m_matrix_sizes(ma)
   {
   }
-  
+
   template<typename T>
   VectorX<T> DummySource<T>::at(size_t index) const {
     if (index >= m_sizes.size()) {
@@ -59,7 +59,7 @@ namespace generic {
     }
     return vec;
   }
-  
+
   template<typename T>
   MatrixX<T> DummySource<T>::matrix_at(size_t index) const {
     if (index >= m_matrix_sizes.size()) {
@@ -85,8 +85,8 @@ namespace generic {
     m_n_outputs(n_outputs)
   {
   }
-  
-  
+
+
   template<typename T>
   VectorX<T> InputNode<T>::compute(const ISource<T>& source) const {
     VectorX<T> output = source.at(m_index);
@@ -99,7 +99,7 @@ namespace generic {
     }
     return output;
   }
-  
+
   template<typename T>
   size_t InputNode<T>::n_outputs() const {
     return m_n_outputs;
@@ -111,12 +111,12 @@ namespace generic {
     m_source(source)
   {
   }
-  
+
   template<typename T>
   VectorX<T> FeedForwardNode<T>::compute(const ISource<T>& source) const {
     return m_stack->compute(m_source->compute(source));
   }
-  
+
   template<typename T>
   size_t FeedForwardNode<T>::n_outputs() const {
     return m_stack->n_outputs();
@@ -146,7 +146,7 @@ namespace generic {
     assert(offset == m_n_outputs);
     return output;
   }
-  
+
   template<typename T>
   size_t ConcatenateNode<T>::n_outputs() const {
     return m_n_outputs;
@@ -159,7 +159,7 @@ namespace generic {
     m_n_outputs(n_outputs)
   {
   }
-  
+
   template<typename T>
   MatrixX<T> InputSequenceNode<T>::scan(const ISource<T>& source) const {
     MatrixX<T> output = source.matrix_at(m_index);
@@ -178,7 +178,7 @@ namespace generic {
   size_t InputSequenceNode<T>::n_outputs() const {
     return m_n_outputs;
   }
-  
+
   template<typename T>
   SequenceNode<T>::SequenceNode(const RecurrentStack<T>* stack,
                                  const ISequenceNode<T>* source) :
@@ -186,12 +186,12 @@ namespace generic {
     m_source(source)
   {
   }
-  
+
   template<typename T>
   MatrixX<T> SequenceNode<T>::scan(const ISource<T>& source) const {
     return m_stack->scan(m_source->scan(source));
   }
-  
+
   template<typename T>
   VectorX<T> SequenceNode<T>::compute(const ISource<T>& src) const {
     MatrixX<T> mat = scan(src);
@@ -202,7 +202,7 @@ namespace generic {
     }
     return mat.col(n_cols - 1);
   }
-  
+
   template<typename T>
   size_t SequenceNode<T>::n_outputs() const {
     return m_stack->n_outputs();
@@ -215,7 +215,7 @@ namespace generic {
     m_source(source)
   {
   }
-  
+
   template<typename T>
   MatrixX<T> TimeDistributedNode<T>::scan(const ISource<T>& source) const {
     MatrixX<T> input = m_source->scan(source);
@@ -226,7 +226,7 @@ namespace generic {
     }
     return output;
   }
-  
+
   template<typename T>
   size_t TimeDistributedNode<T>::n_outputs() const {
     return m_stack->n_outputs();
@@ -237,12 +237,12 @@ namespace generic {
     m_source(source)
   {
   }
-  
+
   template<typename T>
   VectorX<T> SumNode<T>::compute(const ISource<T>& source) const {
     return m_source->scan(source).rowwise().sum();
   }
-  
+
   template<typename T>
   size_t SumNode<T>::n_outputs() const {
     return m_source->n_outputs();
@@ -266,7 +266,7 @@ namespace generic {
         }
     }
   }
-  
+
   // NOTE: you own this pointer!
   template<typename T>
   INode<T>* get_feedforward_node(
@@ -318,7 +318,7 @@ namespace generic {
     }
     return new TimeDistributedNode<T>(stack_map.at(layer_n), source);
   }
-  
+
   // graph
   template<typename T>
   Graph<T>::Graph() {
@@ -330,7 +330,7 @@ namespace generic {
     m_nodes[3] = new FeedForwardNode<T>(m_stacks.at(0), m_nodes.at(2));
     m_last_node = 3;
   }
-  
+
   template<typename T>
   Graph<T>::Graph(const std::vector<NodeConfig>& nodes,
                     const std::vector<LayerConfig>& layers):

--- a/include/lwtnn/generic/InputPreprocessor.hh
+++ b/include/lwtnn/generic/InputPreprocessor.hh
@@ -49,9 +49,6 @@ namespace generic {
 
 } // namespace generic
 
-  using InputPreprocessor = generic::InputPreprocessor<double>;
-  using InputVectorPreprocessor = generic::InputVectorPreprocessor<double>;
-
 } // namespace lwt
 
 #include "InputPreprocessor.tcc"

--- a/include/lwtnn/generic/InputPreprocessor.hh
+++ b/include/lwtnn/generic/InputPreprocessor.hh
@@ -9,13 +9,13 @@
 #include <vector>
 
 namespace lwt {
-    
+
   // use a normal map externally, since these are more common in user
   // code.  TODO: is it worth changing to unordered_map?
   typedef std::map<std::string, double> ValueMap;
   typedef std::vector<std::pair<std::string, double> > ValueVector;
   typedef std::map<std::string, std::vector<double> > VectorMap;
-  
+
 namespace generic {
 
   // ______________________________________________________________________
@@ -46,12 +46,12 @@ namespace generic {
     VectorX<T> m_scales;
     std::vector<std::string> m_names;
   };
-  
+
 } // namespace generic
 
   using InputPreprocessor = generic::InputPreprocessor<double>;
   using InputVectorPreprocessor = generic::InputVectorPreprocessor<double>;
-  
+
 } // namespace lwt
 
 #include "InputPreprocessor.tcc"

--- a/include/lwtnn/generic/InputPreprocessor.tcc
+++ b/include/lwtnn/generic/InputPreprocessor.tcc
@@ -9,16 +9,16 @@ namespace generic {
   // Input preprocessors
 
   // simple feed-forwared version
-  
+
   template<typename T>
   InputPreprocessor<T>::InputPreprocessor(const std::vector<Input>& inputs):
     m_offsets(inputs.size()),
     m_scales(inputs.size())
   {
     static_assert( std::is_same<T, double>::value ||
-                   std::is_assignable<T, double>::value, 
+                   std::is_assignable<T, double>::value,
                    "double cannot be implicitly assigned to T" );
-    
+
     size_t in_num = 0;
     for (const auto& input: inputs) {
       m_offsets(in_num) = input.offset;
@@ -27,7 +27,7 @@ namespace generic {
       in_num++;
     }
   }
-  
+
   template<typename T>
   VectorX<T> InputPreprocessor<T>::operator()(const ValueMap& in) const {
     VectorX<T> invec(m_names.size());
@@ -51,9 +51,9 @@ namespace generic {
     m_scales(inputs.size())
   {
     static_assert( std::is_same<T, double>::value ||
-                   std::is_assignable<T, double>::value, 
+                   std::is_assignable<T, double>::value,
                    "double cannot be implicitly assigned to T" );
-    
+
     size_t in_num = 0;
     for (const auto& input: inputs) {
       m_offsets(in_num) = input.offset;
@@ -67,7 +67,7 @@ namespace generic {
       throw NNConfigurationException("need at least one input");
     }
   }
-  
+
   template<typename T>
   MatrixX<T> InputVectorPreprocessor<T>::operator()(const VectorMap& in) const {
     using namespace Eigen;

--- a/include/lwtnn/generic/LightweightGraph.hh
+++ b/include/lwtnn/generic/LightweightGraph.hh
@@ -51,7 +51,7 @@ namespace lwt {
   typedef std::map<std::string, double> ValueMap;
   // The "VectorMap" is for sequence inputs
   typedef std::map<std::string, std::vector<double> > VectorMap;
-  
+
 namespace generic {
 
   template<typename T> class Graph;
@@ -108,7 +108,7 @@ namespace generic {
     std::map<std::string, size_t> m_output_indices;
     size_t m_default_output;
   };
-  
+
 } // namespace generic
 } // namespace lwt
 

--- a/include/lwtnn/generic/LightweightGraph.tcc
+++ b/include/lwtnn/generic/LightweightGraph.tcc
@@ -16,10 +16,10 @@ namespace {
   class LazySource: public generic::ISource<T>
   {
     typedef typename generic::LightweightGraph<T>::NodeMap NodeMap;
-    typedef InputPreprocessor IP;
+    using IP = generic::InputPreprocessor<T>;
     typedef std::vector<std::pair<std::string, IP*> > Preprocs;
     typedef typename generic::LightweightGraph<T>::SeqNodeMap SeqNodeMap;
-    typedef InputVectorPreprocessor IVP;
+    using IVP = generic::InputVectorPreprocessor<T>;
     typedef std::vector<std::pair<std::string, IVP*> > VecPreprocs;
   public:
     LazySource(const NodeMap&, const SeqNodeMap&,

--- a/include/lwtnn/generic/LightweightGraph.tcc
+++ b/include/lwtnn/generic/LightweightGraph.tcc
@@ -39,7 +39,7 @@ namespace {
     m_nodes(n), m_seqs(s), m_preprocs(p), m_vec_preprocs(v)
   {
   }
-  
+
   template<typename T>
   VectorX<T> LazySource<T>::at(size_t index) const
   {
@@ -50,7 +50,7 @@ namespace {
     const auto& preproc = *proc.second;
     return preproc(m_nodes.at(proc.first));
   }
-  
+
   template<typename T>
   MatrixX<T> LazySource<T>::matrix_at(size_t index) const
   {
@@ -118,7 +118,7 @@ namespace generic {
                                      const SeqNodeMap& seq) const {
     return compute(nodes, seq, m_default_output);
   }
-  
+
   template<typename T>
   ValueMap LightweightGraph<T>::compute(const NodeMap& nodes,
                                      const SeqNodeMap& seq,
@@ -128,7 +128,7 @@ namespace generic {
     }
     return compute(nodes, seq, m_output_indices.at(output));
   }
-  
+
   template<typename T>
   ValueMap LightweightGraph<T>::compute(const NodeMap& nodes,
                                      const SeqNodeMap& seq,
@@ -148,7 +148,7 @@ namespace generic {
                                      const SeqNodeMap& seq) const {
     return scan(nodes, seq, m_default_output);
   }
-  
+
   template<typename T>
   VectorMap LightweightGraph<T>::scan(const NodeMap& nodes,
                                      const SeqNodeMap& seq,
@@ -158,7 +158,7 @@ namespace generic {
     }
     return scan(nodes, seq, m_output_indices.at(output));
   }
-  
+
   template<typename T>
   VectorMap LightweightGraph<T>::scan(const NodeMap& nodes,
                                      const SeqNodeMap& seq,

--- a/include/lwtnn/generic/LightweightNeuralNetwork.hh
+++ b/include/lwtnn/generic/LightweightNeuralNetwork.hh
@@ -26,12 +26,12 @@ namespace lwt {
   typedef std::map<std::string, double> ValueMap;
   typedef std::vector<std::pair<std::string, double> > ValueVector;
   typedef std::map<std::string, std::vector<double> > VectorMap;
-  
+
 namespace generic {
-    
+
   template<typename T> class Stack;
   template<typename T> class ReductionStack;
-  
+
   template<typename T> class InputPreprocessor;
   template<typename T> class InputVectorPreprocessor;
 
@@ -86,7 +86,7 @@ namespace generic {
     std::vector<std::string> m_outputs;
     size_t m_n_inputs;
   };
-  
+
 }
 }
 

--- a/include/lwtnn/generic/LightweightNeuralNetwork.tcc
+++ b/include/lwtnn/generic/LightweightNeuralNetwork.tcc
@@ -75,7 +75,7 @@ namespace generic {
         "Mismatch between NN output dimensions and output labels");
     }
   }
-  
+
   template<typename T>
   LightweightRNN<T>::~LightweightRNN() {
     delete m_stack;
@@ -101,7 +101,7 @@ namespace generic {
 
   // this version should be slightly faster since it only has to sort
   // the inputs once
-  
+
   template<typename T>
   ValueMap LightweightRNN<T>::reduce(const VectorMap& in) const {
     const auto& preproc = *m_vec_preproc;

--- a/include/lwtnn/generic/Source.hh
+++ b/include/lwtnn/generic/Source.hh
@@ -45,10 +45,6 @@ namespace generic {
 
 } // namespace generic
 
-  using ISource = generic::ISource<double>;
-  using VectorSource = generic::VectorSource<double>;
-  using DummySource = generic::DummySource<double>;
-
 } // namespace lwt
 
 #endif //SOURCE_HH

--- a/include/lwtnn/generic/Source.hh
+++ b/include/lwtnn/generic/Source.hh
@@ -17,7 +17,7 @@ namespace generic {
     virtual VectorX<T> at(size_t index) const = 0;
     virtual MatrixX<T> matrix_at(size_t index) const = 0;
   };
-  
+
   template<typename T>
   class VectorSource: public ISource<T>
   {
@@ -29,7 +29,7 @@ namespace generic {
     std::vector<VectorX<T>> m_inputs;
     std::vector<MatrixX<T>> m_matrix_inputs;
   };
-  
+
   template<typename T>
   class DummySource: public ISource<T>
   {
@@ -42,7 +42,7 @@ namespace generic {
     std::vector<size_t> m_sizes;
     std::vector<std::pair<size_t, size_t> > m_matrix_sizes;
   };
-  
+
 } // namespace generic
 
   using ISource = generic::ISource<double>;

--- a/include/lwtnn/generic/Stack.hh
+++ b/include/lwtnn/generic/Stack.hh
@@ -25,24 +25,24 @@
 #include <vector>
 #include <functional>
 
-namespace lwt 
+namespace lwt
 {
-    
+
 namespace generic
 {
-    
+
   template<typename T>
   class ILayer;
-  
+
   template<typename T>
   class IRecurrentLayer;
-  
+
   // ______________________________________________________________________
   // Feed forward Stack class
 
   template<typename T>
   class Stack
-  {      
+  {
   public:
     // constructor for dummy net
     Stack();
@@ -108,7 +108,7 @@ namespace generic
   class BiasLayer: public ILayer<T>
   {
     friend class FittableLWTNN;
-    
+
   public:
     BiasLayer(const VectorX<T>& bias);
     template<typename U> BiasLayer(const std::vector<U>& bias);
@@ -121,7 +121,7 @@ namespace generic
   class MatrixLayer: public ILayer<T>
   {
     friend class FittableLWTNN;
-    
+
   public:
     MatrixLayer(const MatrixX<T>& matrix);
     virtual VectorX<T> compute(const VectorX<T>&) const override;
@@ -133,7 +133,7 @@ namespace generic
   class MaxoutLayer: public ILayer<T>
   {
     friend class FittableLWTNN;
-    
+
   public:
     typedef std::pair<MatrixX<T>, VectorX<T>> InitUnit;
     MaxoutLayer(const std::vector<InitUnit>& maxout_tensor);
@@ -149,7 +149,7 @@ namespace generic
   class NormalizationLayer : public ILayer<T>
   {
     friend class FittableLWTNN;
-    
+
   public:
     NormalizationLayer(const VectorX<T>& W,const VectorX<T>& b);
     virtual VectorX<T> compute(const VectorX<T>&) const override;
@@ -165,7 +165,7 @@ namespace generic
   class HighwayLayer: public ILayer<T>
   {
     friend class FittableLWTNN;
-    
+
   public:
     HighwayLayer(const MatrixX<T>& W,
                  const VectorX<T>& b,
@@ -231,7 +231,7 @@ namespace generic
     virtual ~IRecurrentLayer() {}
     virtual MatrixX<T> scan( const MatrixX<T>&) const = 0;
   };
-  
+
   template<typename T>
   class EmbeddingLayer : public IRecurrentLayer<T>
   {
@@ -247,7 +247,7 @@ namespace generic
 
   /// long short term memory ///
   template<typename T> struct LSTMState;
-  
+
   template<typename T>
   class LSTMLayer : public IRecurrentLayer<T>
   {
@@ -285,11 +285,11 @@ namespace generic
 
     int m_n_outputs;
   };
-  
+
 
   /// gated recurrent unit ///
   template<typename T> struct GRUState;
-  
+
   template<typename T>
   class GRULayer : public IRecurrentLayer<T>
   {
@@ -332,7 +332,7 @@ namespace generic
   template<typename T> T nn_hard_sigmoid( T x );
   template<typename T> T nn_tanh( T x );
   template<typename T> T nn_relu( T x );
-  
+
   template<typename T>
   class ELU
   {
@@ -342,8 +342,8 @@ namespace generic
   private:
     T m_alpha;
   };
-  
-  
+
+
   template<typename T>
   class LeakyReLU
   {
@@ -353,7 +353,7 @@ namespace generic
   private:
     T m_alpha;
   };
-  
+
   template<typename T>
   class Swish
   {
@@ -363,7 +363,7 @@ namespace generic
   private:
     T m_alpha;
   };
-  
+
   template<typename T> std::function<T(T)> get_activation(lwt::ActivationConfig);
 
   // WARNING: you own this pointer! Only call when assigning to member data!
@@ -384,16 +384,16 @@ namespace generic
     MatrixX<T> U;
     VectorX<T> b;
   };
-  
+
   template<typename T> DenseComponents<T> get_component(const lwt::LayerConfig& layer, size_t n_in);
-    
-} // namespace generic    
+
+} // namespace generic
 
   // consistency checks
   void throw_if_not_maxout(const LayerConfig& layer);
   void throw_if_not_dense(const LayerConfig& layer);
   void throw_if_not_normalization(const LayerConfig& layer);
-  
+
 } // namespace lwt
 
 #include "Stack.tcc"

--- a/include/lwtnn/generic/Stack.tcc
+++ b/include/lwtnn/generic/Stack.tcc
@@ -17,7 +17,7 @@ namespace generic {
     m_layers.push_back(new DummyLayer<T>);
     m_layers.push_back(new UnaryActivationLayer<T>({ Activation::SIGMOID, 0.0 }));
     m_layers.push_back(new BiasLayer<T>(std::vector<T>{1, 1, 1, 1}));
-    
+
     MatrixX<T> mat(4, 4);
     mat <<
       0, 0, 0, 1,
@@ -46,7 +46,7 @@ namespace generic {
       layer = 0;
     }
   }
-  
+
   template<typename T>
   VectorX<T> Stack<T>::compute(VectorX<T> in) const {
     for (const auto& layer: m_layers) {
@@ -54,7 +54,7 @@ namespace generic {
     }
     return in;
   }
-  
+
   template<typename T>
   size_t Stack<T>::n_outputs() const {
     return m_n_outputs;
@@ -65,8 +65,8 @@ namespace generic {
   //
   // top level add_layers method. This delegates to the other methods
   // below
-  
-  
+
+
   template<typename T>
   size_t Stack<T>::add_layers(size_t n_inputs, const LayerConfig& layer) {
     if (layer.architecture == Architecture::DENSE) {
@@ -186,7 +186,7 @@ namespace generic {
     m_func(get_activation<T>(act))
   {
   }
-  
+
   template<typename T>
   VectorX<T> UnaryActivationLayer<T>::compute(const VectorX<T>& in) const {
     return in.unaryExpr(m_func);
@@ -212,14 +212,14 @@ namespace generic {
   BiasLayer<T>::BiasLayer(const VectorX<T>& bias): m_bias(bias)
   {
   }
-  
-  template<typename T> 
+
+  template<typename T>
   template<typename U>
   BiasLayer<T>::BiasLayer(const std::vector<U>& bias):
     m_bias(build_vector<T,U>(bias))
   {
   }
-  
+
   template<typename T>
   VectorX<T> BiasLayer<T>::compute(const VectorX<T>& in) const {
     return in + m_bias;
@@ -231,7 +231,7 @@ namespace generic {
     m_matrix(matrix)
   {
   }
-  
+
   template<typename T>
   VectorX<T> MatrixLayer<T>::compute(const VectorX<T>& in) const {
     return m_matrix * in;
@@ -249,7 +249,7 @@ namespace generic {
       out_pos++;
     }
   }
-  
+
   template<typename T>
   VectorX<T> MaxoutLayer<T>::compute(const VectorX<T>& in) const {
     // eigen supports tensors, but only in the experimental component
@@ -271,8 +271,8 @@ namespace generic {
     _W(W), _b(b)
   {
   }
-  
-  
+
+
   template<typename T>
   VectorX<T> NormalizationLayer<T>::compute(const VectorX<T>& in) const {
     VectorX<T> shift = in + _b ;
@@ -290,8 +290,8 @@ namespace generic {
     m_act(get_activation<T>(activation))
   {
   }
-  
-  
+
+
   template<typename T>
   VectorX<T> HighwayLayer<T>::compute(const VectorX<T>& in) const {
     const std::function<T(T)> sig(nn_sigmoid<T>);
@@ -325,7 +325,7 @@ namespace generic {
     }
     m_n_outputs = n_inputs;
   }
-  
+
   template<typename T>
   RecurrentStack<T>::~RecurrentStack() {
     for (auto& layer: m_layers) {
@@ -333,7 +333,7 @@ namespace generic {
       layer = 0;
     }
   }
-  
+
   template<typename T>
   MatrixX<T> RecurrentStack<T>::scan(MatrixX<T> in) const {
     for (auto* layer: m_layers) {
@@ -341,7 +341,7 @@ namespace generic {
     }
     return in;
   }
-  
+
   template<typename T>
   size_t RecurrentStack<T>::n_outputs() const {
     return m_n_outputs;
@@ -409,19 +409,19 @@ namespace generic {
     m_recurrent = new RecurrentStack<T>(n_in, recurrent);
     m_stack = new Stack<T>(m_recurrent->n_outputs(), feed_forward);
   }
-  
+
   template<typename T>
   ReductionStack<T>::~ReductionStack() {
     delete m_recurrent;
     delete m_stack;
   }
-  
+
   template<typename T>
   VectorX<T> ReductionStack<T>::reduce(MatrixX<T> in) const {
     in = m_recurrent->scan(in);
     return m_stack->compute(in.col(in.cols() -1));
   }
-  
+
   template<typename T>
   size_t ReductionStack<T>::n_outputs() const {
     return m_stack->n_outputs();
@@ -513,7 +513,7 @@ namespace generic {
     MatrixX<T> h_t;
     int time;
   };
-  
+
   template<typename T>
   LSTMState<T>::LSTMState(size_t n_input, size_t n_output):
     C_t(MatrixX<T>::Zero(n_output, n_input)),
@@ -584,7 +584,7 @@ namespace generic {
     MatrixX<T> h_t;
     int time;
   };
-  
+
   template<typename T>
   GRUState<T>::GRUState(size_t n_input, size_t n_output):
     h_t(MatrixX<T>::Zero(n_output, n_input)),
@@ -630,8 +630,8 @@ namespace generic {
 
   // Note that in the first case you own this layer! It's your
   // responsibility to delete it.
-  
-  
+
+
   template<typename T>
   ILayer<T>* get_raw_activation_layer(ActivationConfig activation) {
     // Check for special cases. If it's not one, use
@@ -684,7 +684,7 @@ namespace generic {
   Swish<T>::Swish(T alpha):
     m_alpha(alpha)
   {}
-  
+
   template<typename T>
   T Swish<T>::operator()(T x) const {
     return x * nn_sigmoid<T>(m_alpha * x);
@@ -706,7 +706,7 @@ namespace generic {
   ELU<T>::ELU(T alpha):
     m_alpha(alpha)
   {}
-  
+
   template<typename T>
   T ELU<T>::operator()( T x ) const {
     /* ELU function : https://arxiv.org/pdf/1511.07289.pdf
@@ -721,7 +721,7 @@ namespace generic {
   LeakyReLU<T>::LeakyReLU(T alpha):
     m_alpha(alpha)
   {}
-  
+
   template<typename T>
   T LeakyReLU<T>::operator()(T x) const {
     return x > 0 ? x : static_cast<T>(m_alpha * x); // weird autodiff
@@ -733,9 +733,9 @@ namespace generic {
   MatrixX<T1> build_matrix(const std::vector<T2>& weights, size_t n_inputs)
   {
     static_assert( std::is_same<T1, T2>::value ||
-                   std::is_assignable<T1, T2>::value, 
+                   std::is_assignable<T1, T2>::value,
                    "T2 cannot be implicitly assigned to T1" );
-    
+
     size_t n_elements = weights.size();
     if ((n_elements % n_inputs) != 0) {
       std::string problem = "matrix elements not divisible by number"
@@ -753,14 +753,14 @@ namespace generic {
     }
     return matrix;
   }
-  
+
   template<typename T1, typename T2>
-  VectorX<T1> build_vector(const std::vector<T2>& bias) 
+  VectorX<T1> build_vector(const std::vector<T2>& bias)
   {
     static_assert( std::is_same<T1, T2>::value ||
-                   std::is_assignable<T1, T2>::value, 
+                   std::is_assignable<T1, T2>::value,
                    "T2 cannot be implicitly assigned to T1" );
-    
+
     VectorX<T1> out(bias.size());
     size_t idx = 0;
     for (const auto& val: bias) {
@@ -793,7 +793,7 @@ namespace generic {
     }
     return {weights, U, bias};
   }
-  
+
 } // namespace generic
 } // namespace lwt
 

--- a/include/lwtnn/generic/eigen_typedefs.hh
+++ b/include/lwtnn/generic/eigen_typedefs.hh
@@ -4,16 +4,16 @@
 #include <Eigen/Dense>
 
 namespace lwt {
-    
+
   template<typename T>
   using VectorX = Eigen::Matrix<T, Eigen::Dynamic, 1>;
-  
+
   template<typename T>
   using MatrixX = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>;
-  
+
   template<typename T>
   using ArrayX = Eigen::Array<T, Eigen::Dynamic, Eigen::Dynamic>;
-  
+
 }
 
 #endif // LWTNN_EIGEN_TYPEDEFS_HH

--- a/src/LightweightGraph.cxx
+++ b/src/LightweightGraph.cxx
@@ -14,7 +14,7 @@ namespace lwt {
   {
   }
 
-  LightweightGraph::~LightweightGraph() 
+  LightweightGraph::~LightweightGraph()
   {
   }
 
@@ -22,7 +22,7 @@ namespace lwt {
                                      const SeqNodeMap& seq) const {
     return m_impl->compute(nodes, seq);
   }
-  
+
   ValueMap LightweightGraph::compute(const NodeMap& nodes,
                                      const SeqNodeMap& seq,
                                      const std::string& output) const {
@@ -33,7 +33,7 @@ namespace lwt {
                                    const SeqNodeMap& seq) const {
     return m_impl->scan(nodes, seq);
   }
-  
+
   VectorMap LightweightGraph::scan(const NodeMap& nodes,
                                    const SeqNodeMap& seq,
                                    const std::string& output) const {

--- a/src/LightweightNeuralNetwork.cxx
+++ b/src/LightweightNeuralNetwork.cxx
@@ -23,7 +23,7 @@ namespace lwt {
     m_impl(new generic::LightweightNeuralNetwork<double>(inputs, layers, outputs))
   {
   }
-  
+
   LightweightNeuralNetwork::~LightweightNeuralNetwork()
   {
   }
@@ -42,7 +42,7 @@ namespace lwt {
     m_impl(new generic::LightweightRNN<double>(inputs, layers, outputs))
   {
   }
-  
+
   LightweightRNN::~LightweightRNN()
   {
   }

--- a/src/lwtnn-test-graph.cxx
+++ b/src/lwtnn-test-graph.cxx
@@ -1,6 +1,6 @@
 // Use example for Graph class
 
-#include "lwtnn/generic/Graph.hh"
+#include "lwtnn/Graph.hh"
 #include "lwtnn/parse_json.hh"
 #include "lwtnn/NNLayerConfig.hh"
 


### PR DESCRIPTION
This is cleanup after #103. The main changes are:
 - Remove a bunch of trailing whitespace.
 - Add back some headers that were moved into `generic/`, to prevent us from breaking any old code.