### PR TITLE
Add a test for the cmake installation, fix cmake bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,19 +4,12 @@
 /lib
 
 # ignore common data file types
-*.yml
-*.yaml
-*.json
-*.txt
 *.h5
 *.tgz
 *.gz
 
 # except in the tests
 !/tests/data/*
-
-# include the .zenodo file
-!.zenodo.json
 
 # .pyc files
 *.pyc

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ matrix:
   include:
     # minimal build setup
     - packages:
+        - tree
         - cmake
         - libhdf5-serial-dev
       env: MINIMAL=1 BUILD=./tests/travis-build-cmake.sh
@@ -28,6 +29,7 @@ matrix:
 addons:
   apt:
     packages:
+      - tree
       - cmake
       - libhdf5-serial-dev
       - libboost-dev

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,7 +106,21 @@ else()
 endif()
 
 # Public header files for the shared/static library.
-set( lib_headers
+set( concrete_headers
+   include/lwtnn/Exceptions.hh
+   include/lwtnn/Graph.hh
+   include/lwtnn/InputOrder.hh
+   include/lwtnn/InputPreprocessor.hh
+   include/lwtnn/LightweightGraph.hh
+   include/lwtnn/LightweightNeuralNetwork.hh
+   include/lwtnn/NNLayerConfig.hh
+   include/lwtnn/NanReplacer.hh
+   include/lwtnn/Stack.hh
+   include/lwtnn/lightweight_network_config.hh
+   include/lwtnn/lightweight_nn_streamers.hh
+   include/lwtnn/parse_json.hh )
+
+set( generic_headers
    include/lwtnn/generic/eigen_typedefs.hh
    include/lwtnn/generic/Graph.hh
    include/lwtnn/generic/Graph.tcc
@@ -123,13 +137,10 @@ set( lib_headers
    include/lwtnn/generic/FastInputPreprocessor.tcc
    include/lwtnn/generic/FastGraph.hh
    include/lwtnn/generic/FastGraph.tcc
-   include/lwtnn/Exceptions.hh
-   include/lwtnn/LightweightNeuralNetwork.hh
-   include/lwtnn/NNLayerConfig.hh
-   include/lwtnn/NanReplacer.hh
-   include/lwtnn/lightweight_network_config.hh
-   include/lwtnn/lightweight_nn_streamers.hh
-   include/lwtnn/parse_json.hh )
+   )
+
+set( lib_headers "${concrete_headers}" "${generic_headers}")
+
 # Source files for the shared/static library.
 set( lib_sources
    src/Exceptions.cxx
@@ -150,8 +161,6 @@ target_include_directories( lwtnn
    PUBLIC ${EIGEN3_INCLUDE_DIR}
    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>
    PRIVATE ${Boost_INCLUDE_DIRS} )
-set_property( TARGET lwtnn
-   PROPERTY PUBLIC_HEADER ${lib_headers} )
 if( BUILTIN_BOOST )
    add_dependencies( lwtnn Boost )
 endif()
@@ -165,8 +174,6 @@ target_include_directories( lwtnn-stat
    PUBLIC ${EIGEN3_INCLUDE_DIR}
    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>
    PRIVATE ${Boost_INCLUDE_DIRS} )
-set_property( TARGET lwtnn-stat
-   PROPERTY PUBLIC_HEADER ${lib_headers} )
 if( BUILTIN_BOOST )
    add_dependencies( lwtnn-stat Boost )
 endif()
@@ -180,6 +187,8 @@ install( TARGETS lwtnn lwtnn-stat
    ARCHIVE DESTINATION lib
    LIBRARY DESTINATION lib
    PUBLIC_HEADER DESTINATION include/lwtnn )
+
+install( DIRECTORY "include/" DESTINATION "include" )
 
 # Helper macro for building the projects' executables.
 macro( lwtnn_add_executable name )
@@ -242,3 +251,11 @@ configure_file( ${CMAKE_SOURCE_DIR}/cmake/lwtnnConfig-version.cmake.in
 install( FILES ${CMAKE_SOURCE_DIR}/cmake/lwtnnConfig.cmake
    ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/lwtnnConfig-version.cmake
    DESTINATION cmake )
+
+# Attila wrote this list originally, and used 3 spaces for tabs.  I
+# guess we can stick to that.
+#
+# Local Variables:
+# cmake-tab-width: 3
+# End:
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ if( NOT ${CMAKE_VERSION} VERSION_LESS 3.9 )
 endif()
 
 # Set the project's name and version.
-project( lwtnn VERSION 2.11 )
+project( lwtnn VERSION 2.11.1 )
 
 # Enable using CTest in the project.
 include( CTest )

--- a/tests/install/CMakeLists.txt
+++ b/tests/install/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.12)
+project(TestLwtnn)
+
+set( CMAKE_CXX_STANDARD 11 CACHE STRING
+  "C++ standard to use for the build" )
+
+find_package( lwtnn 2.11 REQUIRED )
+add_executable(test-lwtnn test-lwtnn.cxx )
+target_link_libraries( test-lwtnn lwtnn::lwtnn )
+

--- a/tests/install/test-lwtnn.cxx
+++ b/tests/install/test-lwtnn.cxx
@@ -1,0 +1,23 @@
+// basic script to test cmake configuration and linking
+
+#include "lwtnn/LightweightGraph.hh"
+#include "lwtnn/generic/FastGraph.hh"
+#include "lwtnn/parse_json.hh"
+#include <string>
+#include <fstream>
+#include <iostream>
+
+int main(int narg, char* argv[]) {
+  std::string input_file_path = "bludo";
+  if (narg == 1) {
+    input_file_path = argv[1];
+  }
+  std::cout << "testing with " << input_file_path << std::endl;
+  std::ifstream in_file(input_file_path);
+  auto config = lwt::parse_json_graph(in_file);
+
+  lwt::LightweightGraph graph(config);
+  lwt::InputOrder order;
+  lwt::generic::FastGraph<float> fast_graph(config, order);
+  return 0;
+}


### PR DESCRIPTION
There were quite a few things missing if someone used CMake to install this library. 

This should fix a few of them. I also asked the cmake build script in the CI to install the library and then try to build another library and link against it, so hopefully we can catch more of these issues in the future.

The original CMakeLists file was written by @krasznaa, and he has far more experience with CMake than I do, so I'll wait to see if he has any suggestions.