### PR TITLE
Fix compiler warnings in test code

### DIFF
--- a/src/lwtnn-test-graph.cxx
+++ b/src/lwtnn-test-graph.cxx
@@ -63,7 +63,8 @@ namespace {
     using namespace lwt;
     GraphConfig config;
     std::vector<Input> dummy_inputs{ {"one", 0, 1}, {"two", 0, 1} };
-    config.inputs = {{"one", dummy_inputs}, {"two", dummy_inputs}};
+    config.inputs = {{"one", dummy_inputs, {}, {}},
+                     {"two", dummy_inputs, {}, {}}};
     typedef NodeConfig::Type Type;
     // First input layer: read from source object at index 0, expect
     // 2d vector.
@@ -72,7 +73,7 @@ namespace {
     // vector.
     config.nodes.push_back({Type::INPUT, {1}, 2});
     // Concatenate layer: read from layers 0 and 1 above
-    config.nodes.push_back({Type::CONCATENATE, {0, 1}});
+    config.nodes.push_back({Type::CONCATENATE, {0, 1}, 0});
     // Feed forward layer, read from layer 2, apply transform from
     // layer 0 (defined below.
     config.nodes.push_back({Type::FEED_FORWARD, {2}, 0});
@@ -80,8 +81,9 @@ namespace {
     config.nodes.push_back({Type::FEED_FORWARD, {3}, 0});
 
     // Simple dense layer, inverts the input vector
-    LayerConfig dense {
-      {0, 0, 0, 1,  0, 0, 1, 0,  0, 1, 0, 0,  1, 0, 0, 0}};
+    LayerConfig dense;
+    dense.weights = {0, 0, 0, 1,  0, 0, 1, 0,  0, 1, 0, 0,  1, 0, 0, 0};
+    dense.bias = {0, 0, 0, 0};
     dense.activation.function = Activation::LINEAR;
     dense.architecture = Architecture::DENSE;
     config.layers.push_back(dense);

--- a/tests/test-nn-streamers.cxx
+++ b/tests/test-nn-streamers.cxx
@@ -6,6 +6,7 @@
 // System include(s):
 #include <iostream>
 #include <sstream>
+#include <cmath>
 
 /// Class exercising the custom streamers when using a non-std output stream
 ///
@@ -43,8 +44,8 @@ int main() {
    // Print a dumm lwt::LayerConfig object:
    const lwt::LayerConfig dummy2 {
      { 1.0, 2.0 }, { 1.0, 2.0 }, { 1.0, 2.0 },
-     {lwt::Activation::NONE}, {lwt::Activation::NONE},
-     {}, {}, {}, lwt::Architecture::NONE };
+     {lwt::Activation::NONE, NAN}, {lwt::Activation::NONE, NAN},
+     {}, {}, {}, lwt::Architecture::NONE};
    TestStream stream2;
    stream2 << "lwt::LayerConfig: " << dummy2;
    std::cout << stream2.str() << std::endl;


### PR DESCRIPTION
There were several warnings that would appear when compiling test utilities.
None of these utilities should have been used in production code, and there
were no actual bugs, but the warnings were annoying. This commit fixes them.