### PR TITLE
Fix keras conversion for time distributed layers

### DIFF
--- a/converters/keras_v2_layer_converters.py
+++ b/converters/keras_v2_layer_converters.py
@@ -39,7 +39,11 @@ def _get_dense_layer_parameters(h5, layer_config, n_in, layer_type):
 
 def _time_distributed_parameters(h5, layer_config, n_in, layer_type):
     dist_layer = layer_config['layer']['config']
-    dist_layer['name'] = layer_config['name'] # seems slightly hacky...
+    # TODO: Come up with a cleaner way to pass the h5 group
+    # corresponding to the wrapped layer into the layer converter. To
+    # do this we need to figure out exactly how Keras uses the json
+    # archetecture to locate h5 datasets.
+    dist_layer['name'] = layer_config['name']
     dist_name = layer_config['layer']['class_name'].lower()
     return layer_converters[dist_name](h5, dist_layer, n_in, layer_type)
 

--- a/converters/keras_v2_layer_converters.py
+++ b/converters/keras_v2_layer_converters.py
@@ -21,10 +21,7 @@ def _send_recieve_meta_info(backend):
 
 def _get_dense_layer_parameters(h5, layer_config, n_in, layer_type):
     """Get weights, bias, and n-outputs for a dense layer"""
-    if layer_type in ['timedistributed']:
-        layer_group = h5
-    else:
-        layer_group = h5[layer_config['name']]
+    layer_group = h5[layer_config['name']]
     layers = _get_h5_layers(layer_group)
     weights = layers["kernel"+BACKEND_SUFFIX]
     bias = layers["bias"+BACKEND_SUFFIX]
@@ -42,9 +39,9 @@ def _get_dense_layer_parameters(h5, layer_config, n_in, layer_type):
 
 def _time_distributed_parameters(h5, layer_config, n_in, layer_type):
     dist_layer = layer_config['layer']['config']
+    dist_layer['name'] = layer_config['name'] # seems slightly hacky...
     dist_name = layer_config['layer']['class_name'].lower()
-    subgroup = h5[layer_config['name']]
-    return layer_converters[dist_name](subgroup, dist_layer, n_in, layer_type)
+    return layer_converters[dist_name](h5, dist_layer, n_in, layer_type)
 
 def _normalization_parameters(h5, layer_config, n_in, layer_type):
     """Get weights (gamma), bias (beta), for normalization layer"""


### PR DESCRIPTION
The keras converters for time distributed layers missed some edge cases: specifically they weren't supporting time distributed batch normalization layers. This should make the support more generic.