### PR TITLE
Reduce calls to std::function in activation functions

### DIFF
--- a/include/lwtnn/NNLayerConfig.hh
+++ b/include/lwtnn/NNLayerConfig.hh
@@ -13,7 +13,10 @@
 
 namespace lwt {
   enum class Activation {NONE, LINEAR, SIGMOID, RECTIFIED, SOFTMAX, TANH,
-      HARD_SIGMOID, ELU, LEAKY_RELU, SWISH, ABS};
+    HARD_SIGMOID, ELU, LEAKY_RELU, SWISH, ABS,
+    // these "legacy" layers are just around for benchmarking now,
+    // will eventually be removed.
+    SIGMOID_LEGACY, HARD_SIGMOID_LEGACY, TANH_LEGACY, RECTIFIED_LEGACY};
   enum class Architecture {NONE, DENSE, NORMALIZATION, MAXOUT, HIGHWAY,
       LSTM, GRU, EMBEDDING};
   // components (for LSTM, etc)

--- a/include/lwtnn/generic/Stack.hh
+++ b/include/lwtnn/generic/Stack.hh
@@ -24,6 +24,7 @@
 
 #include <vector>
 #include <functional>
+#include <memory>
 
 namespace lwt
 {
@@ -168,7 +169,7 @@ namespace generic
     VectorX<T> m_b_t;
     MatrixX<T> m_w_c;
     VectorX<T> m_b_c;
-    std::function<T(T)> m_act;
+    std::unique_ptr<ILayer<T>> m_act;
   };
 
   // ______________________________________________________________________
@@ -254,8 +255,8 @@ namespace generic
     void step( const VectorX<T>& input, LSTMState<T>& ) const;
 
   private:
-    std::function<T(T)> m_activation_fun;
-    std::function<T(T)> m_inner_activation_fun;
+    std::unique_ptr<ILayer<T>> m_activation_fun;
+    std::unique_ptr<ILayer<T>> m_inner_activation_fun;
 
     MatrixX<T> m_W_i;
     MatrixX<T> m_U_i;
@@ -295,8 +296,8 @@ namespace generic
     void step( const VectorX<T>& input, GRUState<T>& ) const;
 
   private:
-    std::function<T(T)> m_activation_fun;
-    std::function<T(T)> m_inner_activation_fun;
+    std::unique_ptr<ILayer<T>> m_activation_fun;
+    std::unique_ptr<ILayer<T>> m_inner_activation_fun;
 
     MatrixX<T> m_W_z;
     MatrixX<T> m_U_z;

--- a/include/lwtnn/generic/Stack.hh
+++ b/include/lwtnn/generic/Stack.hh
@@ -106,6 +106,36 @@ namespace generic
   };
 
   template<typename T>
+  class ReLULayer: public ILayer<T>
+  {
+    virtual VectorX<T> compute(const VectorX<T>&) const override;
+  };
+
+  template<typename T>
+  class SigmoidLayer: public ILayer<T>
+  {
+    virtual VectorX<T> compute(const VectorX<T>&) const override;
+  };
+
+  template<typename T>
+  class HardSigmoidLayer: public ILayer<T>
+  {
+    virtual VectorX<T> compute(const VectorX<T>&) const override;
+  };
+
+  template<typename T>
+  class TanhLayer: public ILayer<T>
+  {
+    virtual VectorX<T> compute(const VectorX<T>&) const override;
+  };
+
+  template<typename T>
+  class AbsLayer: public ILayer<T>
+  {
+    virtual VectorX<T> compute(const VectorX<T>&) const override;
+  };
+
+  template<typename T>
   class BiasLayer: public ILayer<T>
   {
   public:

--- a/src/parse_json.cxx
+++ b/src/parse_json.cxx
@@ -220,6 +220,12 @@ namespace {
     if (str == "leakyrelu") return Activation::LEAKY_RELU;
     if (str == "swish") return Activation::SWISH;
     if (str == "abs") return Activation::ABS;
+    // legacy activations. These use UnaryActivationLayer. Just around
+    // for benchmarks now.
+    if (str == "sigmoid_legacy") return Activation::SIGMOID_LEGACY;
+    if (str == "hard_sigmoid_legacy") return Activation::HARD_SIGMOID_LEGACY;
+    if (str == "tanh_legacy") return Activation::TANH_LEGACY;
+    if (str == "rectified_legacy") return Activation::RECTIFIED_LEGACY;
     throw std::logic_error("activation function " + str + " not recognized");
     return Activation::LINEAR;
   }

--- a/src/parse_json.cxx
+++ b/src/parse_json.cxx
@@ -1,7 +1,10 @@
 #include "lwtnn/parse_json.hh"
 
+// this is needed to quiet some warnings from boost
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/json_parser.hpp>
+
 #include <cassert>
 #include <string>
 #include <cmath> // for NAN


### PR DESCRIPTION
A few of the activation functions were calling `std::function` on every element, via `UnaryActivationLayer`. This meant dereferencing a pointer for every element, which might cost something. This merge request replaces some of those activation functions with something more efficient.

I'm leaving the older implementations around for the sake of benchmarks. These can be accessed by suffixing the activation name with `_legacy` in the lwtnn configuration files. They will probably be removed in the future, assuming no benchmark indicates a need to keep them.