### PR TITLE
test: Add test build against ltwnn/build-base gcc v11 image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,3 +81,39 @@ jobs:
     - name: Run tests
       run: |
         bash tests/test-runner.sh
+
+  build-base:
+
+    runs-on: ubuntu-latest
+    container: lwtnn/build-base:gcc-v${{ matrix.gcc-version }}
+    strategy:
+      matrix:
+        gcc-version: [11.1.0]
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Install external dependencies with apt
+      run: >-
+        apt-get update -y &&
+        apt-get install -y
+        tree
+        cmake
+        libhdf5-serial-dev
+        libboost-dev
+        libeigen3-dev
+
+    - name: Install Python dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install h5py pyyaml
+        python -m pip list
+
+    - name: Build
+      run: STANDARD=17 ./tests/build-cmake.sh
+
+    - name: Run tests
+      run: |
+        bash tests/test-runner.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,8 @@ name: CI
 
 on:
   push:
-    # branches:
-    # - master
+    branches:
+    - master
   pull_request:
   # Run daily at 0:01 UTC
   schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,8 @@ name: CI
 
 on:
   push:
-    branches:
-    - master
+    # branches:
+    # - master
   pull_request:
   # Run daily at 0:01 UTC
   schedule:


### PR DESCRIPTION
Resolves #136 

This PR adds **testing** against `gcc` `v11` through the use of the [`lwtnn/build-base:gcc-v11.1.0` image](https://github.com/lwtnn/build-base) and is able to reproduce the build failure described in Issue #136. Fixing the build error is out of scope for this PR and should fixed in a follow up PR once this PR has been merged.

**Suggested squash and merge commit message**:

```
* Add CI stage to test the build against gcc v11 using the ltwnn/build-base images
   - c.f. https://github.com/lwtnn/build-base
* Run the test suite using the C++17 standard
```