### PR TITLE
fix: Use 'std::' namespace for size_t

### DIFF
--- a/include/lwtnn/NNLayerConfig.hh
+++ b/include/lwtnn/NNLayerConfig.hh
@@ -66,7 +66,7 @@ namespace lwt {
       INPUT, INPUT_SEQUENCE, FEED_FORWARD, CONCATENATE, SEQUENCE,
       TIME_DISTRIBUTED, SUM };
     Type type;
-    std::vector<size_t> sources;
+    std::vector<std::size_t> sources;
     int index;                  // input node size, or layer number
   };
 }

--- a/include/lwtnn/Stack.hh
+++ b/include/lwtnn/Stack.hh
@@ -41,10 +41,10 @@ namespace lwt
   double nn_relu( double x );
 
   // double typedefs for utility functions
-  MatrixX<double> build_matrix(const std::vector<double>& weights, size_t n_inputs);
+  MatrixX<double> build_matrix(const std::vector<double>& weights, std::size_t n_inputs);
   VectorX<double> build_vector(const std::vector<double>& bias);
 
-  DenseComponents get_component(const lwt::LayerConfig& layer, size_t n_in);
+  DenseComponents get_component(const lwt::LayerConfig& layer, std::size_t n_in);
   std::function<double(double)> get_activation(lwt::ActivationConfig);
 
 }

--- a/include/lwtnn/generic/FastGraph.hh
+++ b/include/lwtnn/generic/FastGraph.hh
@@ -49,7 +49,7 @@ namespace generic {
     VectorX<T> compute(const NodeVec<T>&, const SeqNodeVec<T>& = {}) const;
 
     // the other "compute" which allows you to select an arbitrary output
-    VectorX<T> compute(const NodeVec<T>&, const SeqNodeVec<T>&, size_t) const;
+    VectorX<T> compute(const NodeVec<T>&, const SeqNodeVec<T>&, std::size_t) const;
 
   private:
     typedef FastInputPreprocessor<T> IP;
@@ -60,7 +60,7 @@ namespace generic {
     Graph<T> m_graph;
     Preprocs m_preprocs;
     VecPreprocs m_vec_preprocs;
-    size_t m_default_output;
+    std::size_t m_default_output;
     // the mapping from a node in the network to a user input node
     internal::SourceIndices m_input_indices;
   };

--- a/include/lwtnn/generic/FastGraph.hh
+++ b/include/lwtnn/generic/FastGraph.hh
@@ -24,8 +24,8 @@ namespace generic {
   namespace internal {
     struct SourceIndices
     {
-      std::vector<size_t> scalar;
-      std::vector<size_t> sequence;
+      std::vector<std::size_t> scalar;
+      std::vector<std::size_t> sequence;
     };
   }
 

--- a/include/lwtnn/generic/FastGraph.tcc
+++ b/include/lwtnn/generic/FastGraph.tcc
@@ -82,7 +82,7 @@ namespace internal {
   //
   // Build a mapping from the inputs in the saved network to the
   // inputs that the user is going to hand us.
-  std::vector<size_t> get_node_indices(
+  std::vector<std::size_t> get_node_indices(
     const order_t& order,
     const std::vector<lwt::InputNodeConfig>& inputs);
 

--- a/include/lwtnn/generic/FastGraph.tcc
+++ b/include/lwtnn/generic/FastGraph.tcc
@@ -31,8 +31,8 @@ namespace internal {
     LazySource(const NodeVec<T>&, const SeqNodeVec<T>&,
                const FastPreprocs<T>&, const FastVecPreprocs<T>&,
                const SourceIndices& input_indices);
-    virtual VectorX<T> at(size_t index) const override;
-    virtual MatrixX<T> matrix_at(size_t index) const override;
+    virtual VectorX<T> at(std::size_t index) const override;
+    virtual MatrixX<T> matrix_at(std::size_t index) const override;
   private:
     const NodeVec<T>& m_nodes;
     const SeqNodeVec<T>& m_seqs;
@@ -52,10 +52,10 @@ namespace internal {
   {
   }
   template<typename T>
-  VectorX<T> LazySource<T>::at(size_t index) const
+  VectorX<T> LazySource<T>::at(std::size_t index) const
   {
     const auto& preproc = m_preprocs.at(index);
-    size_t source_index = m_input_indices.scalar.at(index);
+    std::size_t source_index = m_input_indices.scalar.at(index);
     if (source_index >= m_nodes.size()) {
       throw NNEvaluationException(
         "The NN needs an input VectorXd at position "
@@ -65,10 +65,10 @@ namespace internal {
     return preproc(m_nodes.at(source_index));
   }
   template<typename T>
-  MatrixX<T> LazySource<T>::matrix_at(size_t index) const
+  MatrixX<T> LazySource<T>::matrix_at(std::size_t index) const
   {
     const auto& preproc = m_vec_preprocs.at(index);
-    size_t source_index = m_input_indices.sequence.at(index);
+    std::size_t source_index = m_input_indices.sequence.at(index);
     if (source_index >= m_seqs.size()) {
       throw NNEvaluationException(
         "The NN needs an input MatrixXd at position "
@@ -104,15 +104,15 @@ namespace internal {
     m_input_indices.sequence = get_node_indices(
       order.sequence, config.input_sequences);
 
-    for (size_t i = 0; i < config.inputs.size(); i++) {
+    for (std::size_t i = 0; i < config.inputs.size(); i++) {
       const lwt::InputNodeConfig& node = config.inputs.at(i);
-      size_t input_node = m_input_indices.scalar.at(i);
+      std::size_t input_node = m_input_indices.scalar.at(i);
       std::vector<std::string> varorder = order.scalar.at(input_node).second;
       m_preprocs.emplace_back(node.variables, varorder);
     }
-    for (size_t i = 0; i < config.input_sequences.size(); i++) {
+    for (std::size_t i = 0; i < config.input_sequences.size(); i++) {
       const lwt::InputNodeConfig& node = config.input_sequences.at(i);
-      size_t input_node = m_input_indices.sequence.at(i);
+      std::size_t input_node = m_input_indices.sequence.at(i);
       std::vector<std::string> varorder = order.sequence.at(input_node).second;
       m_vec_preprocs.emplace_back(node.variables, varorder);
     }
@@ -140,7 +140,7 @@ namespace internal {
   template<typename T>
   VectorX<T> FastGraph<T>::compute(const NodeVec<T>& nodes,
                                    const SeqNodeVec<T>& seq,
-                                   size_t idx) const {
+                                   std::size_t idx) const {
     using namespace internal;
     LazySource<T> source(nodes, seq, m_preprocs, m_vec_preprocs,
                          m_input_indices);

--- a/include/lwtnn/generic/FastInputPreprocessor.hh
+++ b/include/lwtnn/generic/FastInputPreprocessor.hh
@@ -25,7 +25,7 @@ namespace generic {
     // input transformations
     VectorX<T> m_offsets;
     VectorX<T> m_scales;
-    std::vector<size_t> m_indices;
+    std::vector<std::size_t> m_indices;
   };
 
   template<typename T>
@@ -39,7 +39,7 @@ namespace generic {
     // input transformations
     VectorX<T> m_offsets;
     VectorX<T> m_scales;
-    std::vector<size_t> m_indices;
+    std::vector<std::size_t> m_indices;
   };
 }
 

--- a/include/lwtnn/generic/FastInputPreprocessor.tcc
+++ b/include/lwtnn/generic/FastInputPreprocessor.tcc
@@ -8,7 +8,7 @@
 namespace lwt {
 namespace generic {
 namespace internal {
-  std::vector<size_t> get_value_indices(
+  std::vector<std::size_t> get_value_indices(
     const std::vector<std::string>& order,
     const std::vector<lwt::Input>& inputs);
 } // end internal namespace

--- a/include/lwtnn/generic/FastInputPreprocessor.tcc
+++ b/include/lwtnn/generic/FastInputPreprocessor.tcc
@@ -24,7 +24,7 @@ namespace internal {
     m_offsets(inputs.size()),
     m_scales(inputs.size())
   {
-    size_t in_num = 0;
+    std::size_t in_num = 0;
     for (const auto& input: inputs) {
       m_offsets(in_num) = input.offset;
       m_scales(in_num) = input.scale;
@@ -36,8 +36,8 @@ namespace internal {
   template<typename T>
   VectorX<T> FastInputPreprocessor<T>::operator()(const VectorX<T>& in) const {
     VectorX<T> invec(m_indices.size());
-    size_t input_number = 0;
-    for (size_t index: m_indices) {
+    std::size_t input_number = 0;
+    for (std::size_t index: m_indices) {
       if (static_cast<int>(index) >= in.rows()) {
         throw NNEvaluationException(
           "index " + std::to_string(index) + " is out of range, scalar "
@@ -58,7 +58,7 @@ namespace internal {
     m_offsets(inputs.size()),
     m_scales(inputs.size())
   {
-    size_t in_num = 0;
+    std::size_t in_num = 0;
     for (const auto& input: inputs) {
       m_offsets(in_num) = input.offset;
       m_scales(in_num) = input.scale;
@@ -76,10 +76,10 @@ namespace internal {
   MatrixX<T> FastInputVectorPreprocessor<T>::operator()(const MatrixX<T>& in)
     const {
     using namespace Eigen;
-    size_t n_cols = in.cols();
+    std::size_t n_cols = in.cols();
     MatrixX<T> inmat(m_indices.size(), n_cols);
-    size_t in_num = 0;
-    for (size_t index: m_indices) {
+    std::size_t in_num = 0;
+    for (std::size_t index: m_indices) {
       if (static_cast<int>(index) >= in.rows()) {
         throw NNEvaluationException(
           "index " + std::to_string(index) + " is out of range, sequence "

--- a/include/lwtnn/generic/Graph.hh
+++ b/include/lwtnn/generic/Graph.hh
@@ -142,7 +142,7 @@ namespace generic {
     void build_node(const size_t,
                     const std::vector<NodeConfig>& nodes,
                     const std::vector<LayerConfig>& layers,
-                    std::set<size_t> cycle_check = {});
+                    std::set<std::size_t> cycle_check = {});
 
     std::unordered_map<size_t, INode<T>*> m_nodes;
     size_t m_last_node; // <-- convenience for graphs with one output

--- a/include/lwtnn/generic/Graph.hh
+++ b/include/lwtnn/generic/Graph.hh
@@ -26,19 +26,19 @@ namespace generic {
   public:
     virtual ~INode() {}
     virtual VectorX<T> compute(const ISource<T>&) const = 0;
-    virtual size_t n_outputs() const = 0;
+    virtual std::size_t n_outputs() const = 0;
   };
 
   template<typename T>
   class InputNode: public INode<T>
   {
   public:
-    InputNode(size_t index, size_t n_outputs);
+    InputNode(std::size_t index, std::size_t n_outputs);
     virtual VectorX<T> compute(const ISource<T>&) const override;
-    virtual size_t n_outputs() const override;
+    virtual std::size_t n_outputs() const override;
   private:
-    size_t m_index;
-    size_t m_n_outputs;
+    std::size_t m_index;
+    std::size_t m_n_outputs;
   };
 
   template<typename T>
@@ -47,7 +47,7 @@ namespace generic {
   public:
     FeedForwardNode(const Stack<T>*, const INode<T>* source);
     virtual VectorX<T> compute(const ISource<T>&) const override;
-    virtual size_t n_outputs() const override;
+    virtual std::size_t n_outputs() const override;
   private:
     const Stack<T>* m_stack;
     const INode<T>* m_source;
@@ -59,10 +59,10 @@ namespace generic {
   public:
     ConcatenateNode(const std::vector<const INode<T>*>&);
     virtual VectorX<T> compute(const ISource<T>&) const override;
-    virtual size_t n_outputs() const override;
+    virtual std::size_t n_outputs() const override;
   private:
     std::vector<const INode<T>*> m_sources;
-    size_t m_n_outputs;
+    std::size_t m_n_outputs;
   };
 
   // sequence nodes
@@ -72,19 +72,19 @@ namespace generic {
   public:
     virtual ~ISequenceNode() {}
     virtual MatrixX<T> scan(const ISource<T>&) const = 0;
-    virtual size_t n_outputs() const = 0;
+    virtual std::size_t n_outputs() const = 0;
   };
 
   template<typename T>
   class InputSequenceNode: public ISequenceNode<T>
   {
   public:
-    InputSequenceNode(size_t index, size_t n_outputs);
+    InputSequenceNode(std::size_t index, std::size_t n_outputs);
     virtual MatrixX<T> scan(const ISource<T>&) const override;
-    virtual size_t n_outputs() const override;
+    virtual std::size_t n_outputs() const override;
   private:
-    size_t m_index;
-    size_t m_n_outputs;
+    std::size_t m_index;
+    std::size_t m_n_outputs;
   };
 
   template<typename T>
@@ -94,7 +94,7 @@ namespace generic {
     SequenceNode(const RecurrentStack<T>*, const ISequenceNode<T>* source);
     virtual MatrixX<T> scan(const ISource<T>&) const override;
     virtual VectorX<T> compute(const ISource<T>&) const override;
-    virtual size_t n_outputs() const override;
+    virtual std::size_t n_outputs() const override;
   private:
     const RecurrentStack<T>* m_stack;
     const ISequenceNode<T>* m_source;
@@ -106,7 +106,7 @@ namespace generic {
   public:
     TimeDistributedNode(const Stack<T>*, const ISequenceNode<T>* source);
     virtual MatrixX<T> scan(const ISource<T>&) const override;
-    virtual size_t n_outputs() const override;
+    virtual std::size_t n_outputs() const override;
   private:
     const Stack<T>* m_stack;
     const ISequenceNode<T>* m_source;
@@ -118,7 +118,7 @@ namespace generic {
   public:
     SumNode(const ISequenceNode<T>* source);
     virtual VectorX<T> compute(const ISource<T>&) const override;
-    virtual size_t n_outputs() const override;
+    virtual std::size_t n_outputs() const override;
   private:
     const ISequenceNode<T>* m_source;
   };
@@ -134,21 +134,21 @@ namespace generic {
     Graph(Graph&) = delete;
     Graph& operator=(Graph&) = delete;
     ~Graph();
-    VectorX<T> compute(const ISource<T>&, size_t node_number) const;
+    VectorX<T> compute(const ISource<T>&, std::size_t node_number) const;
     VectorX<T> compute(const ISource<T>&) const;
-    MatrixX<T> scan(const ISource<T>&, size_t node_number) const;
+    MatrixX<T> scan(const ISource<T>&, std::size_t node_number) const;
     MatrixX<T> scan(const ISource<T>&) const;
   private:
-    void build_node(const size_t,
+    void build_node(const std::size_t,
                     const std::vector<NodeConfig>& nodes,
                     const std::vector<LayerConfig>& layers,
                     std::set<std::size_t> cycle_check = {});
 
-    std::unordered_map<size_t, INode<T>*> m_nodes;
-    size_t m_last_node; // <-- convenience for graphs with one output
-    std::unordered_map<size_t, Stack<T>*> m_stacks;
-    std::unordered_map<size_t, ISequenceNode<T>*> m_seq_nodes;
-    std::unordered_map<size_t, RecurrentStack<T>*> m_seq_stacks;
+    std::unordered_map<std::size_t, INode<T>*> m_nodes;
+    std::size_t m_last_node; // <-- convenience for graphs with one output
+    std::unordered_map<std::size_t, Stack<T>*> m_stacks;
+    std::unordered_map<std::size_t, ISequenceNode<T>*> m_seq_nodes;
+    std::unordered_map<std::size_t, RecurrentStack<T>*> m_seq_stacks;
     // At some point maybe also convolutional nodes, but we'd have to
     // have a use case for that first.
   };

--- a/include/lwtnn/generic/Graph.tcc
+++ b/include/lwtnn/generic/Graph.tcc
@@ -21,7 +21,7 @@ namespace generic {
   }
 
   template<typename T>
-  VectorX<T> VectorSource<T>::at(size_t index) const {
+  VectorX<T> VectorSource<T>::at(std::size_t index) const {
     if (index >= m_inputs.size()) {
       throw NNEvaluationException(
         "VectorSource: no source vector defined at " + std::to_string(index));
@@ -30,7 +30,7 @@ namespace generic {
   }
 
   template<typename T>
-  MatrixX<T> VectorSource<T>::matrix_at(size_t index) const {
+  MatrixX<T> VectorSource<T>::matrix_at(std::size_t index) const {
     if (index >= m_matrix_inputs.size()) {
       throw NNEvaluationException(
         "VectorSource: no source matrix defined at " + std::to_string(index));
@@ -40,37 +40,37 @@ namespace generic {
 
   template<typename T>
   DummySource<T>::DummySource(const std::vector<std::size_t>& input_sizes,
-                                const std::vector<std::pair<size_t,size_t> >& ma):
+                                const std::vector<std::pair<std::size_t,std::size_t> >& ma):
     m_sizes(input_sizes),
     m_matrix_sizes(ma)
   {
   }
 
   template<typename T>
-  VectorX<T> DummySource<T>::at(size_t index) const {
+  VectorX<T> DummySource<T>::at(std::size_t index) const {
     if (index >= m_sizes.size()) {
       throw NNEvaluationException(
         "Dummy Source: no size defined at " + std::to_string(index));
     }
-    size_t n_entries = m_sizes.at(index);
+    std::size_t n_entries = m_sizes.at(index);
     VectorX<T> vec(n_entries);
-    for (size_t iii = 0; iii < n_entries; iii++) {
+    for (std::size_t iii = 0; iii < n_entries; iii++) {
       vec(iii) = iii;
     }
     return vec;
   }
 
   template<typename T>
-  MatrixX<T> DummySource<T>::matrix_at(size_t index) const {
+  MatrixX<T> DummySource<T>::matrix_at(std::size_t index) const {
     if (index >= m_matrix_sizes.size()) {
       throw NNEvaluationException(
         "Dummy Source: no size defined at " + std::to_string(index));
     }
-    size_t n_rows = m_matrix_sizes.at(index).first;
-    size_t n_cols = m_matrix_sizes.at(index).second;
+    std::size_t n_rows = m_matrix_sizes.at(index).first;
+    std::size_t n_cols = m_matrix_sizes.at(index).second;
     MatrixX<T> mat(n_rows, n_cols);
-    for (size_t iii = 0; iii < n_rows; iii++) {
-      for (size_t jjj = 0; jjj < n_cols; jjj++) {
+    for (std::size_t iii = 0; iii < n_rows; iii++) {
+      for (std::size_t jjj = 0; jjj < n_cols; jjj++) {
         mat(iii, jjj) = jjj + n_cols * iii;
       }
     }
@@ -80,7 +80,7 @@ namespace generic {
 
   // Nodes
   template<typename T>
-  InputNode<T>::InputNode(size_t index, size_t n_outputs):
+  InputNode<T>::InputNode(std::size_t index, std::size_t n_outputs):
     m_index(index),
     m_n_outputs(n_outputs)
   {
@@ -101,7 +101,7 @@ namespace generic {
   }
 
   template<typename T>
-  size_t InputNode<T>::n_outputs() const {
+  std::size_t InputNode<T>::n_outputs() const {
     return m_n_outputs;
   }
 
@@ -118,7 +118,7 @@ namespace generic {
   }
 
   template<typename T>
-  size_t FeedForwardNode<T>::n_outputs() const {
+  std::size_t FeedForwardNode<T>::n_outputs() const {
     return m_stack->n_outputs();
   }
 
@@ -135,10 +135,10 @@ namespace generic {
   template<typename T>
   VectorX<T> ConcatenateNode<T>::compute(const ISource<T>& source) const {
     VectorX<T> output(m_n_outputs);
-    size_t offset = 0;
+    std::size_t offset = 0;
     for (const auto node: m_sources) {
       VectorX<T> input = node->compute(source);
-      size_t n_elements = input.rows();
+      std::size_t n_elements = input.rows();
       assert(n_elements == node->n_outputs());
       output.segment(offset, n_elements) = input;
       offset += n_elements;
@@ -148,13 +148,13 @@ namespace generic {
   }
 
   template<typename T>
-  size_t ConcatenateNode<T>::n_outputs() const {
+  std::size_t ConcatenateNode<T>::n_outputs() const {
     return m_n_outputs;
   }
 
   // Sequence nodes
   template<typename T>
-  InputSequenceNode<T>::InputSequenceNode(size_t index, size_t n_outputs):
+  InputSequenceNode<T>::InputSequenceNode(std::size_t index, std::size_t n_outputs):
     m_index(index),
     m_n_outputs(n_outputs)
   {
@@ -175,7 +175,7 @@ namespace generic {
     return output;
   }
   template<typename T>
-  size_t InputSequenceNode<T>::n_outputs() const {
+  std::size_t InputSequenceNode<T>::n_outputs() const {
     return m_n_outputs;
   }
 
@@ -195,7 +195,7 @@ namespace generic {
   template<typename T>
   VectorX<T> SequenceNode<T>::compute(const ISource<T>& src) const {
     MatrixX<T> mat = scan(src);
-    size_t n_cols = mat.cols();
+    std::size_t n_cols = mat.cols();
     // special handling for empty sequence
     if (n_cols == 0) {
       return MatrixX<T>::Zero(mat.rows(), 1);
@@ -204,7 +204,7 @@ namespace generic {
   }
 
   template<typename T>
-  size_t SequenceNode<T>::n_outputs() const {
+  std::size_t SequenceNode<T>::n_outputs() const {
     return m_stack->n_outputs();
   }
 
@@ -220,15 +220,15 @@ namespace generic {
   MatrixX<T> TimeDistributedNode<T>::scan(const ISource<T>& source) const {
     MatrixX<T> input = m_source->scan(source);
     MatrixX<T> output(m_stack->n_outputs(), input.cols());
-    size_t n_columns = input.cols();
-    for (size_t col_n = 0; col_n < n_columns; col_n++) {
+    std::size_t n_columns = input.cols();
+    for (std::size_t col_n = 0; col_n < n_columns; col_n++) {
       output.col(col_n) = m_stack->compute(input.col(col_n));
     }
     return output;
   }
 
   template<typename T>
-  size_t TimeDistributedNode<T>::n_outputs() const {
+  std::size_t TimeDistributedNode<T>::n_outputs() const {
     return m_stack->n_outputs();
   }
 
@@ -244,21 +244,21 @@ namespace generic {
   }
 
   template<typename T>
-  size_t SumNode<T>::n_outputs() const {
+  std::size_t SumNode<T>::n_outputs() const {
     return m_source->n_outputs();
   }
 
   namespace {
-    void throw_cfg(std::string msg, size_t index) {
+    void throw_cfg(std::string msg, std::size_t index) {
         throw NNConfigurationException(msg + " " + std::to_string(index));
     }
     void check_compute_node(const NodeConfig& node) {
-        size_t n_source = node.sources.size();
+        std::size_t n_source = node.sources.size();
         if (n_source != 1) throw_cfg("need one source, found", n_source);
         int layer_n = node.index;
         if (layer_n < 0) throw_cfg("negative layer number", layer_n);
     }
-    void check_compute_node(const NodeConfig& node, size_t n_layers) {
+    void check_compute_node(const NodeConfig& node, std::size_t n_layers) {
         check_compute_node(node);
         int layer_n = node.index;
         if (static_cast<std::size_t>(layer_n) >= n_layers) {
@@ -272,8 +272,8 @@ namespace generic {
   INode<T>* get_feedforward_node(
     const NodeConfig& node,
     const std::vector<LayerConfig>& layers,
-    const std::unordered_map<size_t, INode<T>*>& node_map,
-    std::unordered_map<size_t, Stack<T>*>& stack_map) {
+    const std::unordered_map<std::size_t, INode<T>*>& node_map,
+    std::unordered_map<std::size_t, Stack<T>*>& stack_map) {
 
     // FIXME: merge this block with the time distributed one later on
     check_compute_node(node, layers.size());
@@ -289,8 +289,8 @@ namespace generic {
   SequenceNode<T>* get_sequence_node(
     const NodeConfig& node,
     const std::vector<LayerConfig>& layers,
-    const std::unordered_map<size_t, ISequenceNode<T>*>& node_map,
-    std::unordered_map<size_t, RecurrentStack<T>*>& stack_map) {
+    const std::unordered_map<std::size_t, ISequenceNode<T>*>& node_map,
+    std::unordered_map<std::size_t, RecurrentStack<T>*>& stack_map) {
 
     check_compute_node(node, layers.size());
     ISequenceNode<T>* source = node_map.at(node.sources.at(0));
@@ -305,8 +305,8 @@ namespace generic {
   TimeDistributedNode<T>* get_time_distributed_node(
     const NodeConfig& node,
     const std::vector<LayerConfig>& layers,
-    const std::unordered_map<size_t, ISequenceNode<T>*>& node_map,
-    std::unordered_map<size_t, Stack<T>*>& stack_map) {
+    const std::unordered_map<std::size_t, ISequenceNode<T>*>& node_map,
+    std::unordered_map<std::size_t, Stack<T>*>& stack_map) {
 
     // FIXME: merge this block with the FF block above
     check_compute_node(node, layers.size());
@@ -336,7 +336,7 @@ namespace generic {
                     const std::vector<LayerConfig>& layers):
     m_last_node(0)
   {
-    for (size_t iii = 0; iii < nodes.size(); iii++) {
+    for (std::size_t iii = 0; iii < nodes.size(); iii++) {
       build_node(iii, nodes, layers);
     }
     // assert(maps.node.size() + maps.seq_node.size() == nodes.size());
@@ -364,7 +364,7 @@ namespace generic {
     }
   }
   template<typename T>
-  VectorX<T> Graph<T>::compute(const ISource<T>& source, size_t node_number) const {
+  VectorX<T> Graph<T>::compute(const ISource<T>& source, std::size_t node_number) const {
     if (!m_nodes.count(node_number)) {
       auto num = std::to_string(node_number);
       if (m_seq_nodes.count(node_number)) {
@@ -383,7 +383,7 @@ namespace generic {
     return m_nodes.at(m_last_node)->compute(source);
   }
   template<typename T>
-  MatrixX<T> Graph<T>::scan(const ISource<T>& source, size_t node_number) const {
+  MatrixX<T> Graph<T>::scan(const ISource<T>& source, std::size_t node_number) const {
     if (!m_seq_nodes.count(node_number)) {
       auto num = std::to_string(node_number);
       if (m_nodes.count(node_number)) {
@@ -406,7 +406,7 @@ namespace generic {
   // private methods
 
   template<typename T>
-  void Graph<T>::build_node(const size_t iii,
+  void Graph<T>::build_node(const std::size_t iii,
                          const std::vector<NodeConfig>& nodes,
                          const std::vector<LayerConfig>& layers,
                          std::set<std::size_t> cycle_check) {
@@ -424,12 +424,12 @@ namespace generic {
     // if it's an input, build and return
     if (node.type == NodeConfig::Type::INPUT) {
       check_compute_node(node);
-      size_t input_number = node.sources.at(0);
+      std::size_t input_number = node.sources.at(0);
       m_nodes[iii] = new InputNode<T>(input_number, node.index);
       return;
     } else if (node.type == NodeConfig::Type::INPUT_SEQUENCE) {
       check_compute_node(node);
-      size_t input_number = node.sources.at(0);
+      std::size_t input_number = node.sources.at(0);
       m_seq_nodes[iii] = new InputSequenceNode<T>(input_number, node.index);
       return;
     }
@@ -439,7 +439,7 @@ namespace generic {
       throw NNConfigurationException("found cycle in graph");
     }
     cycle_check.insert(iii);
-    for (size_t source_node: node.sources) {
+    for (std::size_t source_node: node.sources) {
       build_node(source_node, nodes, layers, cycle_check);
     }
 
@@ -460,7 +460,7 @@ namespace generic {
     } else if (node.type == NodeConfig::Type::CONCATENATE) {
       // build concatenate layer
       std::vector<const INode<T>*> in_nodes;
-      for (size_t source_node: node.sources) {
+      for (std::size_t source_node: node.sources) {
         in_nodes.push_back(m_nodes.at(source_node));
       }
       m_nodes[iii] = new ConcatenateNode<T>(in_nodes);

--- a/include/lwtnn/generic/Graph.tcc
+++ b/include/lwtnn/generic/Graph.tcc
@@ -39,7 +39,7 @@ namespace generic {
   }
 
   template<typename T>
-  DummySource<T>::DummySource(const std::vector<size_t>& input_sizes,
+  DummySource<T>::DummySource(const std::vector<std::size_t>& input_sizes,
                                 const std::vector<std::pair<size_t,size_t> >& ma):
     m_sizes(input_sizes),
     m_matrix_sizes(ma)
@@ -91,7 +91,7 @@ namespace generic {
   VectorX<T> InputNode<T>::compute(const ISource<T>& source) const {
     VectorX<T> output = source.at(m_index);
     assert(output.rows() > 0);
-    if (static_cast<size_t>(output.rows()) != m_n_outputs) {
+    if (static_cast<std::size_t>(output.rows()) != m_n_outputs) {
       std::string len = std::to_string(output.rows());
       std::string found = std::to_string(m_n_outputs);
       throw NNEvaluationException(
@@ -166,7 +166,7 @@ namespace generic {
     if (output.rows() == 0) {
       throw NNEvaluationException("empty input sequence");
     }
-    if (static_cast<size_t>(output.rows()) != m_n_outputs) {
+    if (static_cast<std::size_t>(output.rows()) != m_n_outputs) {
       std::string len = std::to_string(output.rows());
       std::string found = std::to_string(m_n_outputs);
       throw NNEvaluationException(
@@ -261,7 +261,7 @@ namespace generic {
     void check_compute_node(const NodeConfig& node, size_t n_layers) {
         check_compute_node(node);
         int layer_n = node.index;
-        if (static_cast<size_t>(layer_n) >= n_layers) {
+        if (static_cast<std::size_t>(layer_n) >= n_layers) {
         throw_cfg("no layer number", layer_n);
         }
     }
@@ -409,7 +409,7 @@ namespace generic {
   void Graph<T>::build_node(const size_t iii,
                          const std::vector<NodeConfig>& nodes,
                          const std::vector<LayerConfig>& layers,
-                         std::set<size_t> cycle_check) {
+                         std::set<std::size_t> cycle_check) {
     if (m_nodes.count(iii) || m_seq_nodes.count(iii)) return;
 
     // we insist that the upstream nodes are built before the

--- a/include/lwtnn/generic/InputPreprocessor.tcc
+++ b/include/lwtnn/generic/InputPreprocessor.tcc
@@ -19,7 +19,7 @@ namespace generic {
                    std::is_assignable<T, double>::value,
                    "double cannot be implicitly assigned to T" );
 
-    size_t in_num = 0;
+    std::size_t in_num = 0;
     for (const auto& input: inputs) {
       m_offsets(in_num) = input.offset;
       m_scales(in_num) = input.scale;
@@ -31,7 +31,7 @@ namespace generic {
   template<typename T>
   VectorX<T> InputPreprocessor<T>::operator()(const ValueMap& in) const {
     VectorX<T> invec(m_names.size());
-    size_t input_number = 0;
+    std::size_t input_number = 0;
     for (const auto& in_name: m_names) {
       if (!in.count(in_name)) {
         throw NNEvaluationException("can't find input: " + in_name);
@@ -54,7 +54,7 @@ namespace generic {
                    std::is_assignable<T, double>::value,
                    "double cannot be implicitly assigned to T" );
 
-    size_t in_num = 0;
+    std::size_t in_num = 0;
     for (const auto& input: inputs) {
       m_offsets(in_num) = input.offset;
       m_scales(in_num) = input.scale;
@@ -74,9 +74,9 @@ namespace generic {
     if (in.size() == 0) {
       throw NNEvaluationException("Empty input map");
     }
-    size_t n_cols = in.begin()->second.size();
+    std::size_t n_cols = in.begin()->second.size();
     MatrixX<T> inmat(m_names.size(), n_cols);
-    size_t in_num = 0;
+    std::size_t in_num = 0;
     for (const auto& in_name: m_names) {
       if (!in.count(in_name)) {
         throw NNEvaluationException("can't find input: " + in_name);

--- a/include/lwtnn/generic/LightweightGraph.hh
+++ b/include/lwtnn/generic/LightweightGraph.hh
@@ -99,14 +99,14 @@ namespace generic {
     typedef std::vector<std::pair<std::string, IP*> > Preprocs;
     typedef std::vector<std::pair<std::string, IVP*> > VecPreprocs;
 
-    ValueMap compute(const NodeMap&, const SeqNodeMap&, size_t) const;
-    VectorMap scan(const NodeMap&, const SeqNodeMap&, size_t) const;
+    ValueMap compute(const NodeMap&, const SeqNodeMap&, std::size_t) const;
+    VectorMap scan(const NodeMap&, const SeqNodeMap&, std::size_t) const;
     Graph<T>* m_graph;
     Preprocs m_preprocs;
     VecPreprocs m_vec_preprocs;
-    std::vector<std::pair<size_t, std::vector<std::string> > > m_outputs;
-    std::map<std::string, size_t> m_output_indices;
-    size_t m_default_output;
+    std::vector<std::pair<std::size_t, std::vector<std::string> > > m_outputs;
+    std::map<std::string, std::size_t> m_output_indices;
+    std::size_t m_default_output;
   };
 
 } // namespace generic

--- a/include/lwtnn/generic/LightweightGraph.tcc
+++ b/include/lwtnn/generic/LightweightGraph.tcc
@@ -24,8 +24,8 @@ namespace {
   public:
     LazySource(const NodeMap&, const SeqNodeMap&,
                const Preprocs&, const VecPreprocs&);
-    virtual VectorX<T> at(size_t index) const override;
-    virtual MatrixX<T> matrix_at(size_t index) const override;
+    virtual VectorX<T> at(std::size_t index) const override;
+    virtual MatrixX<T> matrix_at(std::size_t index) const override;
   private:
     const NodeMap& m_nodes;
     const SeqNodeMap& m_seqs;
@@ -41,7 +41,7 @@ namespace {
   }
 
   template<typename T>
-  VectorX<T> LazySource<T>::at(size_t index) const
+  VectorX<T> LazySource<T>::at(std::size_t index) const
   {
     const auto& proc = m_preprocs.at(index);
     if (!m_nodes.count(proc.first)) {
@@ -52,7 +52,7 @@ namespace {
   }
 
   template<typename T>
-  MatrixX<T> LazySource<T>::matrix_at(size_t index) const
+  MatrixX<T> LazySource<T>::matrix_at(std::size_t index) const
   {
     const auto& proc = m_vec_preprocs.at(index);
     if (!m_seqs.count(proc.first)) {
@@ -82,7 +82,7 @@ namespace generic {
       m_vec_preprocs.emplace_back(
         node.name, new InputVectorPreprocessor<T>(node.variables));
     }
-    size_t output_n = 0;
+    std::size_t output_n = 0;
     for (const auto& node: config.outputs) {
       m_outputs.emplace_back(node.second.node_index, node.second.labels);
       m_output_indices.emplace(node.first, output_n);
@@ -132,12 +132,12 @@ namespace generic {
   template<typename T>
   ValueMap LightweightGraph<T>::compute(const NodeMap& nodes,
                                      const SeqNodeMap& seq,
-                                     size_t idx) const {
+                                     std::size_t idx) const {
     LazySource<T> source(nodes, seq, m_preprocs, m_vec_preprocs);
     VectorX<T> result = m_graph->compute(source, m_outputs.at(idx).first);
     const std::vector<std::string>& labels = m_outputs.at(idx).second;
     std::map<std::string, double> output;
-    for (size_t iii = 0; iii < labels.size(); iii++) {
+    for (std::size_t iii = 0; iii < labels.size(); iii++) {
       output[labels.at(iii)] = result(iii);
     }
     return output;
@@ -162,12 +162,12 @@ namespace generic {
   template<typename T>
   VectorMap LightweightGraph<T>::scan(const NodeMap& nodes,
                                      const SeqNodeMap& seq,
-                                     size_t idx) const {
+                                     std::size_t idx) const {
     LazySource<T> source(nodes, seq, m_preprocs, m_vec_preprocs);
     MatrixX<T> result = m_graph->scan(source, m_outputs.at(idx).first);
     const std::vector<std::string>& labels = m_outputs.at(idx).second;
     std::map<std::string, std::vector<double> > output;
-    for (size_t iii = 0; iii < labels.size(); iii++) {
+    for (std::size_t iii = 0; iii < labels.size(); iii++) {
       VectorXd row = result.row(iii);
       std::vector<double> out_vector(row.data(), row.data() + row.size());
       output[labels.at(iii)] = out_vector;

--- a/include/lwtnn/generic/LightweightNeuralNetwork.hh
+++ b/include/lwtnn/generic/LightweightNeuralNetwork.hh
@@ -84,7 +84,7 @@ namespace generic {
     InputPreprocessor<T>* m_preproc;
     InputVectorPreprocessor<T>* m_vec_preproc;
     std::vector<std::string> m_outputs;
-    size_t m_n_inputs;
+    std::size_t m_n_inputs;
   };
 
 }

--- a/include/lwtnn/generic/LightweightNeuralNetwork.tcc
+++ b/include/lwtnn/generic/LightweightNeuralNetwork.tcc
@@ -51,7 +51,7 @@ namespace generic {
 
     // build and return output map
     lwt::ValueMap out_map;
-    for (size_t out_n = 0; out_n < out_size; out_n++) {
+    for (std::size_t out_n = 0; out_n < out_size; out_n++) {
       out_map.emplace(m_outputs.at(out_n), outvec(out_n));
     }
     return out_map;
@@ -87,13 +87,13 @@ namespace generic {
   ValueMap LightweightRNN<T>::reduce(const std::vector<ValueMap>& in) const {
     const auto& preproc = *m_preproc;
     MatrixX<T> inputs(m_n_inputs, in.size());
-    for (size_t iii = 0; iii < in.size(); iii++) {
+    for (std::size_t iii = 0; iii < in.size(); iii++) {
       inputs.col(iii) = preproc(in.at(iii));
     }
     auto outvec = m_stack->reduce(inputs);
     ValueMap out;
     const auto n_rows = static_cast<std::size_t>(outvec.rows());
-    for (size_t iii = 0; iii < n_rows; iii++) {
+    for (std::size_t iii = 0; iii < n_rows; iii++) {
       out.emplace(m_outputs.at(iii), outvec(iii));
     }
     return out;
@@ -108,7 +108,7 @@ namespace generic {
     auto outvec = m_stack->reduce(preproc(in));
     ValueMap out;
     const auto n_rows = static_cast<std::size_t>(outvec.rows());
-    for (size_t iii = 0; iii < n_rows; iii++) {
+    for (std::size_t iii = 0; iii < n_rows; iii++) {
       out.emplace(m_outputs.at(iii), outvec(iii));
     }
     return out;

--- a/include/lwtnn/generic/LightweightNeuralNetwork.tcc
+++ b/include/lwtnn/generic/LightweightNeuralNetwork.tcc
@@ -46,7 +46,7 @@ namespace generic {
     const auto& preproc = *m_preproc;
     auto outvec = m_stack->compute(preproc(in));
     assert(outvec.rows() > 0);
-    auto out_size = static_cast<size_t>(outvec.rows());
+    auto out_size = static_cast<std::size_t>(outvec.rows());
     assert(out_size == m_outputs.size());
 
     // build and return output map
@@ -92,7 +92,7 @@ namespace generic {
     }
     auto outvec = m_stack->reduce(inputs);
     ValueMap out;
-    const auto n_rows = static_cast<size_t>(outvec.rows());
+    const auto n_rows = static_cast<std::size_t>(outvec.rows());
     for (size_t iii = 0; iii < n_rows; iii++) {
       out.emplace(m_outputs.at(iii), outvec(iii));
     }
@@ -107,7 +107,7 @@ namespace generic {
     const auto& preproc = *m_vec_preproc;
     auto outvec = m_stack->reduce(preproc(in));
     ValueMap out;
-    const auto n_rows = static_cast<size_t>(outvec.rows());
+    const auto n_rows = static_cast<std::size_t>(outvec.rows());
     for (size_t iii = 0; iii < n_rows; iii++) {
       out.emplace(m_outputs.at(iii), outvec(iii));
     }

--- a/include/lwtnn/generic/Source.hh
+++ b/include/lwtnn/generic/Source.hh
@@ -14,8 +14,8 @@ namespace generic {
   {
   public:
     virtual ~ISource() = default;
-    virtual VectorX<T> at(size_t index) const = 0;
-    virtual MatrixX<T> matrix_at(size_t index) const = 0;
+    virtual VectorX<T> at(std::size_t index) const = 0;
+    virtual MatrixX<T> matrix_at(std::size_t index) const = 0;
   };
 
   template<typename T>
@@ -23,8 +23,8 @@ namespace generic {
   {
   public:
     VectorSource(std::vector<VectorX<T>>&&, std::vector<MatrixX<T>>&& = {});
-    virtual VectorX<T> at(size_t index) const override;
-    virtual MatrixX<T> matrix_at(size_t index) const override;
+    virtual VectorX<T> at(std::size_t index) const override;
+    virtual MatrixX<T> matrix_at(std::size_t index) const override;
   private:
     std::vector<VectorX<T>> m_inputs;
     std::vector<MatrixX<T>> m_matrix_inputs;
@@ -35,12 +35,12 @@ namespace generic {
   {
   public:
     DummySource(const std::vector<std::size_t>& input_sizes,
-                const std::vector<std::pair<size_t, size_t> >& = {});
-    virtual VectorX<T> at(size_t index) const override;
-    virtual MatrixX<T> matrix_at(size_t index) const override;
+                const std::vector<std::pair<std::size_t, std::size_t> >& = {});
+    virtual VectorX<T> at(std::size_t index) const override;
+    virtual MatrixX<T> matrix_at(std::size_t index) const override;
   private:
     std::vector<std::size_t> m_sizes;
-    std::vector<std::pair<size_t, size_t> > m_matrix_sizes;
+    std::vector<std::pair<std::size_t, std::size_t> > m_matrix_sizes;
   };
 
 } // namespace generic

--- a/include/lwtnn/generic/Source.hh
+++ b/include/lwtnn/generic/Source.hh
@@ -34,12 +34,12 @@ namespace generic {
   class DummySource: public ISource<T>
   {
   public:
-    DummySource(const std::vector<size_t>& input_sizes,
+    DummySource(const std::vector<std::size_t>& input_sizes,
                 const std::vector<std::pair<size_t, size_t> >& = {});
     virtual VectorX<T> at(size_t index) const override;
     virtual MatrixX<T> matrix_at(size_t index) const override;
   private:
-    std::vector<size_t> m_sizes;
+    std::vector<std::size_t> m_sizes;
     std::vector<std::pair<size_t, size_t> > m_matrix_sizes;
   };
 

--- a/include/lwtnn/generic/Stack.hh
+++ b/include/lwtnn/generic/Stack.hh
@@ -48,8 +48,8 @@ namespace generic
     // constructor for dummy net
     Stack();
     // constructor for real net
-    Stack(size_t n_inputs, const std::vector<LayerConfig>& layers,
-          size_t skip_layers = 0);
+    Stack(std::size_t n_inputs, const std::vector<LayerConfig>& layers,
+          std::size_t skip_layers = 0);
     ~Stack();
 
     // make non-copyable for now
@@ -57,17 +57,17 @@ namespace generic
     Stack& operator=(Stack&) = delete;
 
     VectorX<T> compute(VectorX<T>) const;
-    size_t n_outputs() const;
+    std::size_t n_outputs() const;
 
   private:
     // returns the size of the next layer
-    size_t add_layers(size_t n_inputs, const LayerConfig&);
-    size_t add_dense_layers(size_t n_inputs, const LayerConfig&);
-    size_t add_normalization_layers(size_t n_inputs, const LayerConfig&);
-    size_t add_highway_layers(size_t n_inputs, const LayerConfig&);
-    size_t add_maxout_layers(size_t n_inputs, const LayerConfig&);
+    std::size_t add_layers(std::size_t n_inputs, const LayerConfig&);
+    std::size_t add_dense_layers(std::size_t n_inputs, const LayerConfig&);
+    std::size_t add_normalization_layers(std::size_t n_inputs, const LayerConfig&);
+    std::size_t add_highway_layers(std::size_t n_inputs, const LayerConfig&);
+    std::size_t add_maxout_layers(std::size_t n_inputs, const LayerConfig&);
     std::vector<ILayer<T>*> m_layers;
-    size_t m_n_outputs;
+    std::size_t m_n_outputs;
   };
 
   // _______________________________________________________________________
@@ -209,18 +209,18 @@ namespace generic
   class RecurrentStack
   {
   public:
-    RecurrentStack(size_t n_inputs, const std::vector<LayerConfig>& layers);
+    RecurrentStack(std::size_t n_inputs, const std::vector<LayerConfig>& layers);
     ~RecurrentStack();
     RecurrentStack(RecurrentStack&) = delete;
     RecurrentStack& operator=(RecurrentStack&) = delete;
     MatrixX<T> scan(MatrixX<T> inputs) const;
-    size_t n_outputs() const;
+    std::size_t n_outputs() const;
   private:
     std::vector<IRecurrentLayer<T>*> m_layers;
-    size_t add_lstm_layers(size_t n_inputs, const LayerConfig&);
-    size_t add_gru_layers(size_t n_inputs, const LayerConfig&);
-    size_t add_embedding_layers(size_t n_inputs, const LayerConfig&);
-    size_t m_n_outputs;
+    std::size_t add_lstm_layers(std::size_t n_inputs, const LayerConfig&);
+    std::size_t add_gru_layers(std::size_t n_inputs, const LayerConfig&);
+    std::size_t add_embedding_layers(std::size_t n_inputs, const LayerConfig&);
+    std::size_t m_n_outputs;
   };
 
   // This is the old RecurrentStack. Should probably absorb this into
@@ -231,12 +231,12 @@ namespace generic
   class ReductionStack
   {
   public:
-    ReductionStack(size_t n_in, const std::vector<LayerConfig>& layers);
+    ReductionStack(std::size_t n_in, const std::vector<LayerConfig>& layers);
     ~ReductionStack();
     ReductionStack(ReductionStack&) = delete;
     ReductionStack& operator=(ReductionStack&) = delete;
     VectorX<T> reduce(MatrixX<T> inputs) const;
-    size_t n_outputs() const;
+    std::size_t n_outputs() const;
   private:
     RecurrentStack<T>* m_recurrent;
     Stack<T>* m_stack;
@@ -394,7 +394,7 @@ namespace generic
   // utility functions
 
   // functions to build up basic units from vectors
-  template<typename T1, typename T2> MatrixX<T1> build_matrix(const std::vector<T2>& weights, size_t n_inputs);
+  template<typename T1, typename T2> MatrixX<T1> build_matrix(const std::vector<T2>& weights, std::size_t n_inputs);
   template<typename T1, typename T2> VectorX<T1> build_vector(const std::vector<T2>& bias);
 
   // LSTM component for convenience in some layers
@@ -406,7 +406,7 @@ namespace generic
     VectorX<T> b;
   };
 
-  template<typename T> DenseComponents<T> get_component(const lwt::LayerConfig& layer, size_t n_in);
+  template<typename T> DenseComponents<T> get_component(const lwt::LayerConfig& layer, std::size_t n_in);
 
 } // namespace generic
 

--- a/include/lwtnn/generic/Stack.tcc
+++ b/include/lwtnn/generic/Stack.tcc
@@ -154,7 +154,7 @@ namespace generic {
     assert(layer.architecture == Architecture::MAXOUT);
     throw_if_not_maxout(layer);
     std::vector<typename MaxoutLayer<T>::InitUnit> matrices;
-    std::set<size_t> n_outputs;
+    std::set<std::size_t> n_outputs;
     for (const auto& sublayer: layer.sublayers) {
       MatrixX<T> matrix = build_matrix<T>(sublayer.weights, n_inputs);
       VectorX<T> bias = build_vector<T>(sublayer.bias);

--- a/include/lwtnn/generic/Stack.tcc
+++ b/include/lwtnn/generic/Stack.tcc
@@ -30,9 +30,9 @@ namespace generic {
 
   // construct from LayerConfig
   template<typename T>
-  Stack<T>::Stack(size_t n_inputs, const std::vector<LayerConfig>& layers,
-               size_t skip) {
-    for (size_t nnn = skip; nnn < layers.size(); nnn++) {
+  Stack<T>::Stack(std::size_t n_inputs, const std::vector<LayerConfig>& layers,
+               std::size_t skip) {
+    for (std::size_t nnn = skip; nnn < layers.size(); nnn++) {
       n_inputs = add_layers(n_inputs, layers.at(nnn));
     }
     // the final assigned n_inputs is the number of output nodes
@@ -56,7 +56,7 @@ namespace generic {
   }
 
   template<typename T>
-  size_t Stack<T>::n_outputs() const {
+  std::size_t Stack<T>::n_outputs() const {
     return m_n_outputs;
   }
 
@@ -68,7 +68,7 @@ namespace generic {
 
 
   template<typename T>
-  size_t Stack<T>::add_layers(size_t n_inputs, const LayerConfig& layer) {
+  std::size_t Stack<T>::add_layers(std::size_t n_inputs, const LayerConfig& layer) {
     if (layer.architecture == Architecture::DENSE) {
       return add_dense_layers(n_inputs, layer);
     } else if (layer.architecture == Architecture::NORMALIZATION){
@@ -82,11 +82,11 @@ namespace generic {
   }
 
   template<typename T>
-  size_t Stack<T>::add_dense_layers(size_t n_inputs, const LayerConfig& layer) {
+  std::size_t Stack<T>::add_dense_layers(std::size_t n_inputs, const LayerConfig& layer) {
     assert(layer.architecture == Architecture::DENSE);
     throw_if_not_dense(layer);
 
-    size_t n_outputs = n_inputs;
+    std::size_t n_outputs = n_inputs;
 
     // add matrix layer
     if (layer.weights.size() > 0) {
@@ -115,7 +115,7 @@ namespace generic {
   }
 
   template<typename T>
-  size_t Stack<T>::add_normalization_layers(size_t n_inputs, const LayerConfig& layer) {
+  std::size_t Stack<T>::add_normalization_layers(std::size_t n_inputs, const LayerConfig& layer) {
     assert(layer.architecture == Architecture::NORMALIZATION);
     throw_if_not_normalization(layer);
 
@@ -138,7 +138,7 @@ namespace generic {
 
 
   template<typename T>
-  size_t Stack<T>::add_highway_layers(size_t n_inputs, const LayerConfig& layer) {
+  std::size_t Stack<T>::add_highway_layers(std::size_t n_inputs, const LayerConfig& layer) {
     auto& comps = layer.components;
     const auto& t = get_component<T>(comps.at(Component::T), n_inputs);
     const auto& c = get_component<T>(comps.at(Component::CARRY), n_inputs);
@@ -150,7 +150,7 @@ namespace generic {
 
 
   template<typename T>
-  size_t Stack<T>::add_maxout_layers(size_t n_inputs, const LayerConfig& layer) {
+  std::size_t Stack<T>::add_maxout_layers(std::size_t n_inputs, const LayerConfig& layer) {
     assert(layer.architecture == Architecture::MAXOUT);
     throw_if_not_maxout(layer);
     std::vector<typename MaxoutLayer<T>::InitUnit> matrices;
@@ -196,10 +196,10 @@ namespace generic {
   VectorX<T> SoftmaxLayer<T>::compute(const VectorX<T>& in) const {
     // More numerically stable softmax, as suggested in
     // http://stackoverflow.com/a/34969389
-    size_t n_elements = in.rows();
+    std::size_t n_elements = in.rows();
     VectorX<T> expv(n_elements);
     T max = in.maxCoeff();
-    for (size_t iii = 0; iii < n_elements; iii++) {
+    for (std::size_t iii = 0; iii < n_elements; iii++) {
       using std::exp; // weird autodiff ...
       expv(iii) = exp(in(iii) - max);
     }
@@ -285,10 +285,10 @@ namespace generic {
   VectorX<T> MaxoutLayer<T>::compute(const VectorX<T>& in) const {
     // eigen supports tensors, but only in the experimental component
     // for now just stick to matrix and vector classes
-    const size_t n_mat = m_matrices.size();
-    const size_t out_dim = m_matrices.front().rows();
+    const std::size_t n_mat = m_matrices.size();
+    const std::size_t out_dim = m_matrices.front().rows();
     MatrixX<T> outputs(n_mat, out_dim);
-    for (size_t mat_n = 0; mat_n < n_mat; mat_n++) {
+    for (std::size_t mat_n = 0; mat_n < n_mat; mat_n++) {
       outputs.row(mat_n) = m_matrices.at(mat_n) * in;
     }
     outputs += m_bias;
@@ -335,12 +335,12 @@ namespace generic {
   // Recurrent Stack
 
   template<typename T>
-  RecurrentStack<T>::RecurrentStack(size_t n_inputs,
+  RecurrentStack<T>::RecurrentStack(std::size_t n_inputs,
                                  const std::vector<lwt::LayerConfig>& layers)
   {
     using namespace lwt;
-    const size_t n_layers = layers.size();
-    for (size_t layer_n = 0; layer_n < n_layers; layer_n++) {
+    const std::size_t n_layers = layers.size();
+    for (std::size_t layer_n = 0; layer_n < n_layers; layer_n++) {
       auto& layer = layers.at(layer_n);
 
       // add recurrent layers (now LSTM and GRU!)
@@ -374,12 +374,12 @@ namespace generic {
   }
 
   template<typename T>
-  size_t RecurrentStack<T>::n_outputs() const {
+  std::size_t RecurrentStack<T>::n_outputs() const {
     return m_n_outputs;
   }
 
   template<typename T>
-  size_t RecurrentStack<T>::add_lstm_layers(size_t n_inputs,
+  std::size_t RecurrentStack<T>::add_lstm_layers(std::size_t n_inputs,
                                          const LayerConfig& layer) {
     auto& comps = layer.components;
     const auto& i = get_component<T>(comps.at(Component::I), n_inputs);
@@ -396,7 +396,7 @@ namespace generic {
   }
 
   template<typename T>
-  size_t RecurrentStack<T>::add_gru_layers(size_t n_inputs,
+  std::size_t RecurrentStack<T>::add_gru_layers(std::size_t n_inputs,
                                          const LayerConfig& layer) {
     auto& comps = layer.components;
     const auto& z = get_component<T>(comps.at(Component::Z), n_inputs);
@@ -411,11 +411,11 @@ namespace generic {
   }
 
   template<typename T>
-  size_t RecurrentStack<T>::add_embedding_layers(size_t n_inputs,
+  std::size_t RecurrentStack<T>::add_embedding_layers(std::size_t n_inputs,
                                               const LayerConfig& layer) {
     for (const auto& emb: layer.embedding) {
-      size_t n_wt = emb.weights.size();
-      size_t n_cats = n_wt / emb.n_out;
+      std::size_t n_wt = emb.weights.size();
+      std::size_t n_cats = n_wt / emb.n_out;
       MatrixX<T> mat = build_matrix<T>(emb.weights, n_cats);
       m_layers.push_back(new EmbeddingLayer<T>(emb.index, mat));
       n_inputs += emb.n_out - 1;
@@ -424,7 +424,7 @@ namespace generic {
   }
 
   template<typename T>
-  ReductionStack<T>::ReductionStack(size_t n_in,
+  ReductionStack<T>::ReductionStack(std::size_t n_in,
                                  const std::vector<LayerConfig>& layers) {
     std::vector<LayerConfig> recurrent;
     std::vector<LayerConfig> feed_forward;
@@ -454,7 +454,7 @@ namespace generic {
   }
 
   template<typename T>
-  size_t ReductionStack<T>::n_outputs() const {
+  std::size_t ReductionStack<T>::n_outputs() const {
     return m_stack->n_outputs();
   }
 
@@ -540,14 +540,14 @@ namespace generic {
   // internal structure created on each scan call
   template<typename T>
   struct LSTMState {
-    LSTMState(size_t n_input, size_t n_outputs);
+    LSTMState(std::size_t n_input, std::size_t n_outputs);
     MatrixX<T> C_t;
     MatrixX<T> h_t;
     int time;
   };
 
   template<typename T>
-  LSTMState<T>::LSTMState(size_t n_input, size_t n_output):
+  LSTMState<T>::LSTMState(std::size_t n_input, std::size_t n_output):
     C_t(MatrixX<T>::Zero(n_output, n_input)),
     h_t(MatrixX<T>::Zero(n_output, n_input)),
     time(0)
@@ -613,13 +613,13 @@ namespace generic {
   // internal structure created on each scan call
   template<typename T>
   struct GRUState {
-    GRUState(size_t n_input, size_t n_outputs);
+    GRUState(std::size_t n_input, std::size_t n_outputs);
     MatrixX<T> h_t;
     int time;
   };
 
   template<typename T>
-  GRUState<T>::GRUState(size_t n_input, size_t n_output):
+  GRUState<T>::GRUState(std::size_t n_input, std::size_t n_output):
     h_t(MatrixX<T>::Zero(n_output, n_input)),
     time(0)
   {
@@ -789,22 +789,22 @@ namespace generic {
   };
 
   template<typename T1, typename T2>
-  MatrixX<T1> build_matrix(const std::vector<T2>& weights, size_t n_inputs)
+  MatrixX<T1> build_matrix(const std::vector<T2>& weights, std::size_t n_inputs)
   {
     static_assert( conversion_check<T1,T2>::value,
                    "T2 cannot be implicitly assigned to T1" );
 
-    size_t n_elements = weights.size();
+    std::size_t n_elements = weights.size();
     if ((n_elements % n_inputs) != 0) {
       std::string problem = "matrix elements not divisible by number"
         " of columns. Elements: " + std::to_string(n_elements) +
         ", Inputs: " + std::to_string(n_inputs);
       throw lwt::NNConfigurationException(problem);
     }
-    size_t n_outputs = n_elements / n_inputs;
+    std::size_t n_outputs = n_elements / n_inputs;
     MatrixX<T1> matrix(n_outputs, n_inputs);
-    for (size_t row = 0; row < n_outputs; row++) {
-      for (size_t col = 0; col < n_inputs; col++) {
+    for (std::size_t row = 0; row < n_outputs; row++) {
+      for (std::size_t col = 0; col < n_inputs; col++) {
         T1 element = weights.at(col + row * n_inputs);
         matrix(row, col) = element;
       }
@@ -819,7 +819,7 @@ namespace generic {
                    "T2 cannot be implicitly assigned to T1" );
 
     VectorX<T1> out(bias.size());
-    size_t idx = 0;
+    std::size_t idx = 0;
     for (const auto& val: bias) {
       out(idx) = val;
       idx++;
@@ -829,19 +829,19 @@ namespace generic {
 
   // component-wise getters (for Highway, lstm, etc)
   template<typename T>
-  DenseComponents<T> get_component(const lwt::LayerConfig& layer, size_t n_in) {
+  DenseComponents<T> get_component(const lwt::LayerConfig& layer, std::size_t n_in) {
     using namespace Eigen;
     using namespace lwt;
     MatrixX<T> weights = build_matrix<T, double>(layer.weights, n_in);
-    size_t n_out = weights.rows();
+    std::size_t n_out = weights.rows();
     VectorX<T> bias = build_vector<T, double>(layer.bias);
 
     // the u element is optional
-    size_t u_el = layer.U.size();
+    std::size_t u_el = layer.U.size();
     MatrixX<T> U = u_el ? build_matrix<T, double>(layer.U, n_out) : MatrixX<T>::Zero(0,0);
 
-    size_t u_out = U.rows();
-    size_t b_out = bias.rows();
+    std::size_t u_out = U.rows();
+    std::size_t b_out = bias.rows();
     bool u_mismatch = (u_out != n_out) && (u_out > 0);
     if ( u_mismatch || b_out != n_out) {
       throw NNConfigurationException(

--- a/include/lwtnn/lightweight_network_config.hh
+++ b/include/lwtnn/lightweight_network_config.hh
@@ -48,7 +48,7 @@ namespace lwt {
   struct OutputNodeConfig
   {
     std::vector<std::string> labels;
-    size_t node_index;
+    std::size_t node_index;
   };
   struct GraphConfig
   {

--- a/src/FastGraph.cxx
+++ b/src/FastGraph.cxx
@@ -14,8 +14,8 @@ namespace internal {
     const order_t& order,
     const std::vector<lwt::InputNodeConfig>& inputs)
   {
-    std::map<std::string, size_t> order_indices;
-    for (size_t i = 0; i < order.size(); i++) {
+    std::map<std::string, std::size_t> order_indices;
+    for (std::size_t i = 0; i < order.size(); i++) {
       order_indices[order.at(i).first] = i;
     }
     std::vector<std::size_t> node_indices;

--- a/src/FastGraph.cxx
+++ b/src/FastGraph.cxx
@@ -10,7 +10,7 @@ namespace internal {
   //
   // Build a mapping from the inputs in the saved network to the
   // inputs that the user is going to hand us.
-  std::vector<size_t> get_node_indices(
+  std::vector<std::size_t> get_node_indices(
     const order_t& order,
     const std::vector<lwt::InputNodeConfig>& inputs)
   {
@@ -18,7 +18,7 @@ namespace internal {
     for (size_t i = 0; i < order.size(); i++) {
       order_indices[order.at(i).first] = i;
     }
-    std::vector<size_t> node_indices;
+    std::vector<std::size_t> node_indices;
     for (const lwt::InputNodeConfig& input: inputs) {
       if (!order_indices.count(input.name)) {
         throw NNConfigurationException("Missing input " + input.name);

--- a/src/FastInputPreprocessor.cxx
+++ b/src/FastInputPreprocessor.cxx
@@ -3,7 +3,7 @@
 namespace lwt {
 namespace generic {
 namespace internal {
-  std::vector<size_t> get_value_indices(
+  std::vector<std::size_t> get_value_indices(
     const std::vector<std::string>& order,
     const std::vector<lwt::Input>& inputs)
   {
@@ -11,7 +11,7 @@ namespace internal {
     for (size_t i = 0; i < order.size(); i++) {
       order_indices[order.at(i)] = i;
     }
-    std::vector<size_t> value_indices;
+    std::vector<std::size_t> value_indices;
     for (const lwt::Input& input: inputs) {
       if (!order_indices.count(input.name)) {
         throw lwt::NNConfigurationException("Missing input " + input.name);

--- a/src/FastInputPreprocessor.cxx
+++ b/src/FastInputPreprocessor.cxx
@@ -7,8 +7,8 @@ namespace internal {
     const std::vector<std::string>& order,
     const std::vector<lwt::Input>& inputs)
   {
-    std::map<std::string, size_t> order_indices;
-    for (size_t i = 0; i < order.size(); i++) {
+    std::map<std::string, std::size_t> order_indices;
+    for (std::size_t i = 0; i < order.size(); i++) {
       order_indices[order.at(i)] = i;
     }
     std::vector<std::size_t> value_indices;

--- a/src/Stack.cxx
+++ b/src/Stack.cxx
@@ -28,7 +28,7 @@ namespace lwt
     return generic::nn_relu<double>(x);
   }
 
-  MatrixX<double> build_matrix(const std::vector<double>& weights, size_t n_inputs) {
+  MatrixX<double> build_matrix(const std::vector<double>& weights, std::size_t n_inputs) {
     return generic::build_matrix<double, double>(weights, n_inputs);
   }
 
@@ -36,7 +36,7 @@ namespace lwt
     return generic::build_vector<double, double>(bias);
   }
 
-  DenseComponents get_component(const lwt::LayerConfig& layer, size_t n_in) {
+  DenseComponents get_component(const lwt::LayerConfig& layer, std::size_t n_in) {
     return generic::get_component<double>(layer, n_in);
   }
 

--- a/src/lightweight_nn_streamers.cxx
+++ b/src/lightweight_nn_streamers.cxx
@@ -8,8 +8,8 @@
 namespace lwt {
   std::ostream& operator<<(std::ostream& out,
 			   const std::vector<double>& vec) {
-    size_t nentry = vec.size();
-    for (size_t iii = 0; iii < nentry; iii++) {
+    std::size_t nentry = vec.size();
+    for (std::size_t iii = 0; iii < nentry; iii++) {
       out << vec.at(iii);
       if (iii < (nentry - 1)) out << ", ";
     }

--- a/src/lwtnn-benchmark-rnn.cxx
+++ b/src/lwtnn-benchmark-rnn.cxx
@@ -20,7 +20,7 @@ std::vector<lwt::ValueMap> get_values(
   const std::vector<lwt::Input>& inputs) {
   Eigen::MatrixXd test_pattern = Eigen::MatrixXd::Random(inputs.size(), 40);
   std::vector<lwt::ValueMap> out;
-  const auto n_cols = static_cast<size_t>(test_pattern.cols());
+  const auto n_cols = static_cast<std::size_t>(test_pattern.cols());
   for (size_t iii = 0; iii < n_cols; iii++) {
     lwt::ValueMap vals;
     for (size_t jjj = 0; jjj < inputs.size(); jjj++) {
@@ -36,7 +36,7 @@ lwt::VectorMap get_values_vec(const std::vector<lwt::Input>& inputs) {
   lwt::VectorMap out;
   for (size_t in_num = 0; in_num < inputs.size(); in_num++) {
     std::vector<double> ins;
-    const auto n_cols = static_cast<size_t>(test_pattern.cols());
+    const auto n_cols = static_cast<std::size_t>(test_pattern.cols());
     for (size_t iii = 0; iii < n_cols; iii++) {
       ins.push_back(test_pattern(in_num, iii));
     }

--- a/src/lwtnn-benchmark-rnn.cxx
+++ b/src/lwtnn-benchmark-rnn.cxx
@@ -21,9 +21,9 @@ std::vector<lwt::ValueMap> get_values(
   Eigen::MatrixXd test_pattern = Eigen::MatrixXd::Random(inputs.size(), 40);
   std::vector<lwt::ValueMap> out;
   const auto n_cols = static_cast<std::size_t>(test_pattern.cols());
-  for (size_t iii = 0; iii < n_cols; iii++) {
+  for (std::size_t iii = 0; iii < n_cols; iii++) {
     lwt::ValueMap vals;
-    for (size_t jjj = 0; jjj < inputs.size(); jjj++) {
+    for (std::size_t jjj = 0; jjj < inputs.size(); jjj++) {
       vals[inputs.at(jjj).name] = test_pattern(jjj, iii);
     }
     out.push_back(vals);
@@ -34,10 +34,10 @@ std::vector<lwt::ValueMap> get_values(
 lwt::VectorMap get_values_vec(const std::vector<lwt::Input>& inputs) {
   Eigen::MatrixXd test_pattern = Eigen::MatrixXd::Random(inputs.size(), 40);
   lwt::VectorMap out;
-  for (size_t in_num = 0; in_num < inputs.size(); in_num++) {
+  for (std::size_t in_num = 0; in_num < inputs.size(); in_num++) {
     std::vector<double> ins;
     const auto n_cols = static_cast<std::size_t>(test_pattern.cols());
-    for (size_t iii = 0; iii < n_cols; iii++) {
+    for (std::size_t iii = 0; iii < n_cols; iii++) {
       ins.push_back(test_pattern(in_num, iii));
     }
     out[inputs.at(in_num).name] = std::move(ins);
@@ -66,14 +66,14 @@ int main(int argc, char* argv[]) {
               << std::endl;
   }
 
-  size_t n_inputs = config.inputs.size();
+  std::size_t n_inputs = config.inputs.size();
   lwt::ReductionStack stack(n_inputs, config.layers);
   lwt::LightweightRNN rnn(config.inputs, config.layers, config.outputs);
   Eigen::VectorXd sum_outputs = Eigen::VectorXd::Zero(stack.n_outputs());
-  size_t n_loops = 1;
+  std::size_t n_loops = 1;
   std::cout << "running over " << n_loops << " loops" << std::endl;
   std::cout << "running " << (run_stack ? "fast": "slow") << std::endl;
-  for (size_t nnn = 0; nnn < n_loops; nnn++) {
+  for (std::size_t nnn = 0; nnn < n_loops; nnn++) {
     if (run_stack) {
       Eigen::MatrixXd test_pattern = Eigen::MatrixXd::Random(n_inputs, 2);
       std::cout << test_pattern << std::endl;
@@ -81,7 +81,7 @@ int main(int argc, char* argv[]) {
     } else {
       const auto inputs = get_values_vec(config.inputs);
       auto out = rnn.reduce(inputs);
-      for (size_t iii = 0; iii < config.outputs.size(); iii++) {
+      for (std::size_t iii = 0; iii < config.outputs.size(); iii++) {
         sum_outputs(iii) += out.at(config.outputs.at(iii));
       }
     }

--- a/src/lwtnn-test-arbitrary-net.cxx
+++ b/src/lwtnn-test-arbitrary-net.cxx
@@ -56,8 +56,8 @@ namespace {
       config.inputs, config.layers, config.outputs);
     std::map<std::string, double> in_vals;
 
-    const size_t total_inputs = config.inputs.size();
-    for (size_t nnn = 0; nnn < total_inputs; nnn++) {
+    const std::size_t total_inputs = config.inputs.size();
+    for (std::size_t nnn = 0; nnn < total_inputs; nnn++) {
       const auto& input = config.inputs.at(nnn);
       double ramp_val = ramp(input, nnn, total_inputs);
       in_vals[input.name] = ramp_val;
@@ -90,7 +90,7 @@ namespace {
       if (val_strings.size() == 0) continue;
       assert(val_strings.size() == labels.size());
       std::map<std::string, double> nn_in;
-      for (size_t iii = 0; iii < labels.size(); iii++) {
+      for (std::size_t iii = 0; iii < labels.size(); iii++) {
         nn_in[labels.at(iii)] = std::stof(val_strings.at(iii));
       }
       auto cleaned_inputs = replacer.replace(nn_in);

--- a/src/lwtnn-test-fastgraph.cxx
+++ b/src/lwtnn-test-fastgraph.cxx
@@ -23,7 +23,7 @@ namespace {
   lwt::VectorX<T> get_input_vec(const std::vector<lwt::Input>& inputs);
   template<typename T>
   lwt::MatrixX<T> get_input_mat(const std::vector<lwt::Input>& inputs,
-                                size_t n_patterns);
+                                std::size_t n_patterns);
 }
 
 
@@ -98,21 +98,21 @@ namespace {
 
   template<typename T>
   lwt::VectorX<T> get_input_vec(const std::vector<lwt::Input>& inputs) {
-    size_t n_inputs = inputs.size();
+    std::size_t n_inputs = inputs.size();
     lwt::VectorX<T> out(n_inputs);
-    for (size_t nnn = 0; nnn < n_inputs; nnn++) {
+    for (std::size_t nnn = 0; nnn < n_inputs; nnn++) {
       out(nnn) = ramp(inputs.at(nnn), nnn, n_inputs);
     }
     return out;
   }
   template<typename T>
   lwt::MatrixX<T> get_input_mat(const std::vector<lwt::Input>& inputs,
-                                size_t n_patterns) {
-    size_t n_inputs = inputs.size();
+                                std::size_t n_patterns) {
+    std::size_t n_inputs = inputs.size();
     lwt::MatrixX<T> out(n_inputs, n_patterns);
-    for (size_t nnn = 0; nnn < n_inputs; nnn++) {
+    for (std::size_t nnn = 0; nnn < n_inputs; nnn++) {
       const auto& input = inputs.at(nnn);
-      for (size_t jjj = 0; jjj < n_patterns; jjj++) {
+      for (std::size_t jjj = 0; jjj < n_patterns; jjj++) {
         out(nnn,jjj) = ramp(input, nnn, jjj, n_inputs, n_patterns);
       }
     }

--- a/src/lwtnn-test-graph.cxx
+++ b/src/lwtnn-test-graph.cxx
@@ -35,7 +35,7 @@ int main(int argc, char* argv[]) {
   // input nodes will request Eigen::MatrixXd and VectorXd objects
   // from the source object.
   using namespace lwt;
-  std::vector<size_t> inputs_per_node;
+  std::vector<std::size_t> inputs_per_node;
   for (const auto& innode: config.inputs) {
     inputs_per_node.push_back(innode.variables.size());
   }

--- a/src/lwtnn-test-graph.cxx
+++ b/src/lwtnn-test-graph.cxx
@@ -39,7 +39,7 @@ int main(int argc, char* argv[]) {
   for (const auto& innode: config.inputs) {
     inputs_per_node.push_back(innode.variables.size());
   }
-  std::vector<std::pair<size_t, size_t> > inputs_per_seq_node;
+  std::vector<std::pair<std::size_t, std::size_t> > inputs_per_seq_node;
   for (const auto& innode: config.input_sequences) {
     inputs_per_seq_node.emplace_back(innode.variables.size(),20UL);
   }

--- a/src/lwtnn-test-lightweight-graph.cxx
+++ b/src/lwtnn-test-lightweight-graph.cxx
@@ -72,9 +72,9 @@ namespace {
     // header.
     std::map<std::string, std::map<std::string, double> > in_nodes;
     for (const auto& input: config) {
-      const size_t total_inputs = input.variables.size();
+      const std::size_t total_inputs = input.variables.size();
       std::map<std::string, double> in_vals;
-      for (size_t nnn = 0; nnn < total_inputs; nnn++) {
+      for (std::size_t nnn = 0; nnn < total_inputs; nnn++) {
         const auto& var = input.variables.at(nnn);
         double ramp_val = ramp(var, nnn, total_inputs);
         in_vals[var.name] = ramp_val;

--- a/src/lwtnn-test-rnn.cxx
+++ b/src/lwtnn-test-rnn.cxx
@@ -94,7 +94,7 @@ namespace {
       auto val_strings = parse_line(val_line);
       if (val_strings.size() == 0) continue;
       assert(val_strings.size() == labels.size());
-      for (size_t iii = 0; iii < labels.size(); iii++) {
+      for (std::size_t iii = 0; iii < labels.size(); iii++) {
         in[labels.at(iii)].push_back(std::stof(val_strings.at(iii)));
       }
     }

--- a/src/test_utilities.cxx
+++ b/src/test_utilities.cxx
@@ -3,15 +3,15 @@
 #include <sstream>
 #include <cassert>
 
-double ramp(const lwt::Input& in, size_t pos, size_t n_entries) {
+double ramp(const lwt::Input& in, std::size_t pos, std::size_t n_entries) {
   double step = 2.0 / (n_entries - 1);
   double x = ( (n_entries == 1) ? -1 : (-1 + pos * step) );
   return x / in.scale - in.offset;
 }
 
 // 2d ramp function, see declaration above
-double ramp(const lwt::Input& in, size_t x, size_t y,
-            size_t n_x, size_t n_y) {
+double ramp(const lwt::Input& in, std::size_t x, std::size_t y,
+            std::size_t n_x, std::size_t n_y) {
   assert(x < n_x);
   assert(y < n_y);
   double s_x = 2.0 / (n_x - 1);
@@ -23,15 +23,15 @@ double ramp(const lwt::Input& in, size_t x, size_t y,
 
 
 lwt::VectorMap get_values_vec(const std::vector<lwt::Input>& inputs,
-                              size_t n_patterns) {
+                              std::size_t n_patterns) {
   lwt::VectorMap out;
 
   // ramp through the input multiplier
-  const size_t total_inputs = inputs.size();
-  for (size_t nnn = 0; nnn < total_inputs; nnn++) {
+  const std::size_t total_inputs = inputs.size();
+  for (std::size_t nnn = 0; nnn < total_inputs; nnn++) {
     const auto& input = inputs.at(nnn);
     out[input.name] = {};
-    for (size_t jjj = 0; jjj < n_patterns; jjj++) {
+    for (std::size_t jjj = 0; jjj < n_patterns; jjj++) {
       double ramp_val = ramp(input, nnn, jjj, total_inputs, n_patterns);
       out.at(input.name).push_back(ramp_val);
     }

--- a/src/test_utilities.hh
+++ b/src/test_utilities.hh
@@ -12,7 +12,7 @@
 
 // ramp function so that the inputs _after_ normalization fall on the
 // [-1,1] range, i.e. `np.linspace(-1, 1, n_entries)`
-double ramp(const lwt::Input& in, size_t pos, size_t n_entries);
+double ramp(const lwt::Input& in, std::size_t pos, std::size_t n_entries);
 
 // 2d ramp function, corners in (x, y) are (-1, -1), (1, 1), linear
 // interpolation in the grid between. This can be reproduced in numpy
@@ -20,11 +20,11 @@ double ramp(const lwt::Input& in, size_t pos, size_t n_entries);
 //
 // np.linspace(-1, 1, 20)[:,None] * np.linspace(-1, 1, n_features)[None,:]
 //
-double ramp(const lwt::Input& in, size_t x, size_t y,
-            size_t n_x, size_t n_y);
+double ramp(const lwt::Input& in, std::size_t x, std::size_t y,
+            std::size_t n_x, std::size_t n_y);
 
 lwt::VectorMap get_values_vec(const std::vector<lwt::Input>& inputs,
-                                size_t n_patterns);
+                                std::size_t n_patterns);
 
 std::vector<std::string> parse_line(std::string& line);
 


### PR DESCRIPTION
Resolves #138 

This is enough to resolve namespace issues with `gcc` `v11`.

Replacing `size_t` with `std::size_t` everywhere avoids (as @dguest has pointed out)

>  included C libraries leaking up into the C++ code

and hopefully any further issues with this. All instances in the codebase are changed as can be seen by


```console
$ git grep "size_t" | grep -v "std::"
```

returning nothing.

It is technically enough to just change all instances that appear in a `std::vector` to resolve Issue #138, but this PR gets all instances to avoid future problems.

**Suggested squash and merge commit message**:

```
* Use 'std::' namespace for size_t everywhere in the codebase
   - Avoid problems with collisions of C libraries
```

This should ideally be merged _after_ PR #137 is merged.