### PR TITLE
ci: Add C++20 C++ standard to testing matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: [3.7, 3.8, 3.9]
-        build-system: ["make", "tests/build-cmake.sh", "STANDARD=17 tests/build-cmake.sh"]
+        build-system: ["make", "tests/build-cmake.sh", "STANDARD=17 tests/build-cmake.sh", "STANDARD=20 tests/build-cmake.sh"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,7 @@ jobs:
     strategy:
       matrix:
         gcc-version: [11.1.0]
+        cxx-standard: [17, 20]
 
     steps:
     - uses: actions/checkout@v2
@@ -112,7 +113,7 @@ jobs:
         python -m pip list
 
     - name: Build
-      run: STANDARD=17 ./tests/build-cmake.sh
+      run: STANDARD=${{ matrix.cxx-standard }} ./tests/build-cmake.sh
 
     - name: Run tests
       run: |


### PR DESCRIPTION
Resolves #140 

Add C++20 to both GHA server jobs (`test`) and to containerized `lwtnn/build-base` environment tests.

**Suggested squash and merge commit message**:

```
* Add C++20 as a tested C++ standard in CI
   - Add 'STANDARD=20' to build matrix 'build-system' options in tests job
   - Add 'cxx-standard' as built matrix option in build-base job and add 20 as option
```