### PR TITLE
feat: Set range of valid CMake versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,11 @@ jobs:
         libhdf5-serial-dev
         libboost-dev
         libeigen3-dev
+    - name: List build tools available
+      run: |
+        gcc --version
+        g++ --version
+        cmake --version
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
@@ -105,6 +110,12 @@ jobs:
         libhdf5-serial-dev
         libboost-dev
         libeigen3-dev
+
+    - name: List build tools available
+      run: |
+        gcc --version
+        g++ --version
+        cmake --version
 
     - name: Install Python dependencies
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,10 @@
 
-# Set the minimum CMake version required to build the project.
-cmake_minimum_required( VERSION 3.1 )
+# Set range of valid CMake versions to build the project.
+cmake_minimum_required(VERSION 3.1...3.20)
+
+if(${CMAKE_VERSION} VERSION_LESS 3.12)
+    cmake_policy(VERSION ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION})
+endif()
 
 # Silence some warnings on macOS with new CMake versions.
 if( NOT ${CMAKE_VERSION} VERSION_LESS 3.9 )

--- a/tests/install/CMakeLists.txt
+++ b/tests/install/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.12...3.20)
 project(TestLwtnn)
 
 set( CMAKE_CXX_STANDARD 11 CACHE STRING


### PR DESCRIPTION
If only one CMake version is given to `cmake_minimum_required` then CMake will force that version to be used, even if a more updated CMake version is available. So instead of providing only a single CMake version, provide a range of supported CMake versions.

c.f. [An Introduction to Modern CMake](https://cliutils.gitlab.io/modern-cmake/chapters/basics.html) by Henry Schreiner (@henryiii)

**Suggested squash and merge commit message**:

```
* If only one CMake version is given to cmake_minimum_required then
  CMake will force that version to be used, even if a more updated CMake
  version is available. So instead of providing only a single CMake
  version, provide a range of supported CMake versions.
   - c.f. An Introduction to Modern CMake by Henry Schreiner
   - https://cliutils.gitlab.io/modern-cmake/chapters/basics.html
* List build tools available as step in CI for debugging spot checks
```