### PR TITLE
Migrate json parser to nlohmann_json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         tree
         cmake
         libhdf5-serial-dev
-        libboost-dev
+        nlohmann-json-dev
         libeigen3-dev
     - name: List build tools available
       run: |
@@ -108,7 +108,7 @@ jobs:
         tree
         cmake
         libhdf5-serial-dev
-        libboost-dev
+        nlohmann-json-dev
         libeigen3-dev
 
     - name: List build tools available

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 # Set range of valid CMake versions to build the project.
-cmake_minimum_required(VERSION 3.1...3.20)
+cmake_minimum_required(VERSION 3.11...3.20)
 
 if(${CMAKE_VERSION} VERSION_LESS 3.12)
     cmake_policy(VERSION ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION})
@@ -53,32 +53,20 @@ list( INSERT CMAKE_MODULE_PATH 0 ${CMAKE_SOURCE_DIR}/cmake )
 # available on the build system, or downloading the necessary code as part
 # of the build of this project.
 
-# Figure out what to do with Boost.
-option( BUILTIN_BOOST "Acquire Boost as part of building this project" OFF )
-if( BUILTIN_BOOST )
-   # Download and install the Boost headers using ExternalProject. Note that
-   # we don't need any of the Boost libraries, so we're not using Boost's own
-   # build system. And we only need the Boost headers during the build
-   # "privately", so the headers are not installed with the project.
-   include( ExternalProject )
-   ExternalProject_Add( Boost
-      PREFIX ${CMAKE_BINARY_DIR}/externals
-      INSTALL_DIR ${CMAKE_BINARY_DIR}/externals/Boost
-      URL "https://lcgpackages.web.cern.ch/tarFiles/sources/boost_1_64_0.tar.gz"
-      URL_HASH SHA256=0445c22a5ef3bd69f5dfb48354978421a85ab395254a26b1ffb0aa1bfd63a108
-      BUILD_IN_SOURCE 1
-      CONFIGURE_COMMAND ${CMAKE_COMMAND} -E echo "No configuration for Boost"
-      BUILD_COMMAND ${CMAKE_COMMAND} -E echo "No build step for Boost"
-      INSTALL_COMMAND ${CMAKE_COMMAND} -E copy_directory <SOURCE_DIR>/boost
-      <INSTALL_DIR>/include/boost )
-   # Set the include path to use.
-   set( Boost_INCLUDE_DIRS
-      $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/externals/Boost/include> )
-   # Tell the user what will happen.
-   message( STATUS "Using a privately downloaded Boost version for the build" )
-else()
-   # Look for Boost on the build system.
-   find_package( Boost 1.54.0 REQUIRED )
+# Figure out what to do with nlohmann.
+option( BUILTIN_NLOHMANN_JSON "Acquire nlohmann_json as part of building this project" OFF )
+if( BUILTIN_NLOHMANN_JSON )
+   include(FetchContent)
+
+   FetchContent_Declare(json
+      GIT_REPOSITORY https://github.com/nlohmann/json
+      GIT_TAG v3.9.1)
+
+   FetchContent_GetProperties(json)
+   if(NOT json_POPULATED)
+      FetchContent_Populate(json)
+      add_subdirectory(${json_SOURCE_DIR} ${json_BINARY_DIR} EXCLUDE_FROM_ALL)
+   endif()
 endif()
 
 # Figure out what to do with Eigen.
@@ -163,9 +151,11 @@ add_library( lwtnn SHARED ${lib_headers} ${lib_sources} )
 target_include_directories( lwtnn
    PUBLIC ${EIGEN3_INCLUDE_DIR}
    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>
-   PRIVATE ${Boost_INCLUDE_DIRS} )
-if( BUILTIN_BOOST )
-   add_dependencies( lwtnn Boost )
+   PRIVATE nlohmann_json::nlohmann_json )
+target_link_libraries( lwtnn
+   PRIVATE nlohmann_json::nlohmann_json )
+if( BUILTIN_NLOHMANN_JSON )
+   add_dependencies( lwtnn nlohmann_json )
 endif()
 if( BUILTIN_EIGEN )
    add_dependencies( lwtnn Eigen )
@@ -176,9 +166,11 @@ add_library( lwtnn-stat ${lib_headers} ${lib_sources} )
 target_include_directories( lwtnn-stat
    PUBLIC ${EIGEN3_INCLUDE_DIR}
    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>
-   PRIVATE ${Boost_INCLUDE_DIRS} )
-if( BUILTIN_BOOST )
-   add_dependencies( lwtnn-stat Boost )
+   PRIVATE nlohmann_json::nlohmann_json )
+target_link_libraries( lwtnn-stat
+   PRIVATE nlohmann_json::nlohmann_json )
+if( BUILTIN_NLOHMANN_JSON )
+   add_dependencies( lwtnn-stat nlohmann_json )
 endif()
 if( BUILTIN_EIGEN )
    add_dependencies( lwtnn-stat Eigen )
@@ -199,7 +191,7 @@ macro( lwtnn_add_executable name )
    add_executable( ${name} src/${name}.cxx )
    # Set its properties.
    target_link_libraries( ${name} lwtnn-stat )
-   target_include_directories( ${name} SYSTEM PRIVATE ${Boost_INCLUDE_DIRS} )
+   target_include_directories( ${name} SYSTEM PRIVATE nlohmann_json::nlohmann_json )
    # Install it.
    install( TARGETS ${name}
       EXPORT lwtnnTargets

--- a/include/lwtnn/NNLayerConfig.hh
+++ b/include/lwtnn/NNLayerConfig.hh
@@ -63,7 +63,7 @@ namespace lwt {
   struct NodeConfig
   {
     enum class Type {
-      INPUT, INPUT_SEQUENCE, FEED_FORWARD, CONCATENATE, SEQUENCE,
+      NONE, INPUT, INPUT_SEQUENCE, FEED_FORWARD, CONCATENATE, SEQUENCE,
       TIME_DISTRIBUTED, SUM };
     Type type;
     std::vector<std::size_t> sources;

--- a/src/parse_json.cxx
+++ b/src/parse_json.cxx
@@ -1,203 +1,104 @@
 #include "lwtnn/parse_json.hh"
 
-// this is needed to quiet some warnings from boost
-#define BOOST_BIND_GLOBAL_PLACEHOLDERS
-#include <boost/property_tree/ptree.hpp>
-#include <boost/property_tree/json_parser.hpp>
+#include <nlohmann/json.hpp>
 
-#include <cassert>
 #include <string>
 #include <cmath> // for NAN
-#include <set>
 
 namespace {
-  using namespace boost::property_tree;
   using namespace lwt;
-  LayerConfig get_layer(const ptree::value_type& pt);
-  Input get_input(const ptree::value_type& pt);
-  InputNodeConfig get_input_node(const ptree::value_type& pt);
-  NodeConfig get_node(const ptree::value_type& pt);
-  OutputNodeConfig get_output_node(const ptree::value_type& v);
-  NodeConfig::Type get_node_type(const std::string&);
-  ActivationConfig get_activation(const ptree&);
-  Activation get_activation_function(const std::string&);
-  Architecture get_architecture(const std::string&);
-  void set_defaults(LayerConfig& lc);
-  void add_dense_info(LayerConfig& lc, const ptree::value_type& pt);
-  void add_maxout_info(LayerConfig& lc, const ptree::value_type& pt);
-  void add_component_info(LayerConfig& lc, const ptree::value_type& pt);
-  void add_embedding_info(LayerConfig& lc, const ptree::value_type& pt);
-
-  std::map<std::string, double> get_defaults(const ptree& ptree);
+  void add_dense_info(LayerConfig& lc, const nlohmann::json& j);
+  void add_maxout_info(LayerConfig& lc, const nlohmann::json& j);
+  void add_component_info(LayerConfig& lc, const nlohmann::json& j);
+  void add_embedding_info(LayerConfig& lc, const nlohmann::json& j);
 }
 
 
 namespace lwt {
+  //
+  // Define JSON mapping of enum classes
+  //
+  NLOHMANN_JSON_SERIALIZE_ENUM( Architecture, {
+      {Architecture::NONE, "none"},   // need to be first, will also be used for unknown values
+      {Architecture::DENSE, "dense"},
+      {Architecture::NORMALIZATION, "normalization"},
+      {Architecture::HIGHWAY, "highway"},
+      {Architecture::MAXOUT, "maxout"},
+      {Architecture::LSTM, "lstm"},
+      {Architecture::GRU, "gru"},
+      {Architecture::SIMPLERNN, "simplernn"},
+      {Architecture::EMBEDDING, "embedding"}
+    } )
+  NLOHMANN_JSON_SERIALIZE_ENUM( NodeConfig::Type, {
+      {NodeConfig::Type::NONE, "none"},
+      {NodeConfig::Type::FEED_FORWARD, "feed_forward"},
+      {NodeConfig::Type::SEQUENCE, "sequence"},
+      {NodeConfig::Type::INPUT, "input"},
+      {NodeConfig::Type::CONCATENATE, "concatenate"},
+      {NodeConfig::Type::TIME_DISTRIBUTED, "time_distributed"},
+      {NodeConfig::Type::SUM, "sum"}
+    } )
+  NLOHMANN_JSON_SERIALIZE_ENUM( Activation, {
+      {Activation::NONE, "none"},
+      {Activation::LINEAR, "linear"},
+      {Activation::SIGMOID, "sigmoid"},
+      {Activation::RECTIFIED, "rectified"},
+      {Activation::SOFTMAX, "softmax"},
+      {Activation::TANH, "tanh"},
+      {Activation::HARD_SIGMOID, "hard_sigmoid"},
+      {Activation::ELU, "elu"},
+      {Activation::LEAKY_RELU, "leakyrelu"},
+      {Activation::SWISH, "swish"},
+      {Activation::ABS, "abs"},
+      // legacy activations. These use UnaryActivationLayer. Just around
+      // for benchmarks now.
+      {Activation::SIGMOID_LEGACY, "sigmoid_legacy"},
+      {Activation::HARD_SIGMOID_LEGACY, "hard_sigmoid_legacy"},
+      {Activation::TANH_LEGACY, "tanh_legacy"},
+      {Activation::RECTIFIED_LEGACY, "rectified_legacy"}
+    } )
+  NLOHMANN_JSON_SERIALIZE_ENUM( Component, {
+      {Component::I, "i"},
+      {Component::O, "o"},
+      {Component::C, "c"},
+      {Component::F, "f"},
+      {Component::Z, "z"},
+      {Component::R, "r"},
+      {Component::H, "h"},
+      {Component::T, "t"},
+      {Component::CARRY, "carry"}
+    } )
 
-  JSONConfig parse_json(std::istream& json)
-  {
-    boost::property_tree::ptree pt;
-    boost::property_tree::read_json(json, pt);
+  // Dummy `to_json` methods required even if not used
+  void to_json(nlohmann::json&, const ActivationConfig&) {}
+  void to_json(nlohmann::json&, const LayerConfig&) {}
+  void to_json(nlohmann::json&, const NodeConfig&) {}
+  void to_json(nlohmann::json&, const JSONConfig&) {}
 
-    JSONConfig cfg;
-    for (const auto& v: pt.get_child("inputs")) {
-      cfg.inputs.push_back(get_input(v));
-    }
-    for (const auto& v: pt.get_child("layers")) {
-      cfg.layers.push_back(get_layer(v));
-    }
-    for (const auto& v: pt.get_child("outputs"))
-    {
-      assert(v.first.empty()); // array elements have no names
-      cfg.outputs.push_back(v.second.data());
-    }
-    cfg.defaults = get_defaults(pt);
-    const std::string mname = "miscellaneous";
-    if (pt.count(mname)) {
-      for (const auto& misc: pt.get_child(mname)) {
-        cfg.miscellaneous.emplace(
-          misc.first, misc.second.get_value<std::string>());
-      }
-    }
-    return cfg;
-  }
+  // `from_json` converters for structs that require special treatment
+  void from_json(const nlohmann::json& j, ActivationConfig& cfg);
+  void from_json(const nlohmann::json& j, LayerConfig& cfg);
+  void from_json(const nlohmann::json& j, NodeConfig& cfg);
+  void from_json(const nlohmann::json& j, JSONConfig& cfg);
 
+  // "Simple" structs that map directly to JSON
+  NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE( Input, name, offset, scale )
+  NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE( InputNodeConfig, name, variables ) // defaults, miscellaneous done manually
+  NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE( OutputNodeConfig, labels, node_index )
+  NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE( EmbeddingConfig, weights, index, n_out )
+  NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE( GraphConfig, inputs, input_sequences, nodes, outputs, layers )
 
-  GraphConfig parse_json_graph(std::istream& json) {
-    boost::property_tree::ptree pt;
-    boost::property_tree::read_json(json, pt);
-
-    GraphConfig cfg;
-    for (const auto& v: pt.get_child("inputs")) {
-      cfg.inputs.push_back(get_input_node(v));
-    }
-    for (const auto& v: pt.get_child("input_sequences")) {
-      cfg.input_sequences.push_back(get_input_node(v));
-    }
-    for (const auto& v: pt.get_child("nodes")) {
-      cfg.nodes.push_back(get_node(v));
-    }
-    for (const auto& v: pt.get_child("layers")) {
-      cfg.layers.push_back(get_layer(v));
-    }
-    for (const auto& v: pt.get_child("outputs")) {
-      cfg.outputs.emplace(v.first, get_output_node(v));
-    }
-    return cfg;
-  }
-
-}
-
-namespace {
-
-  lwt::Input get_input(const ptree::value_type& v) {
-    std::string name = v.second.get<std::string>("name");
-    auto offset = v.second.get<double>("offset");
-    auto scale = v.second.get<double>("scale");
-    return {name, offset, scale};
-  }
-
-  lwt::InputNodeConfig get_input_node(const ptree::value_type& v) {
-    InputNodeConfig cfg;
-    cfg.name = v.second.get<std::string>("name");
-    for (const auto& var: v.second.get_child("variables")) {
-      cfg.variables.push_back(get_input(var));
-      if (var.second.count("default")) {
-        std::string name = var.second.get<std::string>("name");
-        cfg.defaults.emplace(name, var.second.get<double>("default"));
-      }
-    }
-    return cfg;
-  }
-
-  const std::set<NodeConfig::Type> layerless_nodes {
-    NodeConfig::Type::CONCATENATE, NodeConfig::Type::SUM };
-  NodeConfig get_node(const ptree::value_type& v) {
-    NodeConfig cfg;
-
-    for (const auto& source: v.second.get_child("sources")) {
-      int source_number = source.second.get_value<int>();
-      if (source_number < 0) {
-        throw std::logic_error("node source number must be positive");
-      }
-      cfg.sources.push_back(source_number);
-    }
-
-    cfg.type = get_node_type(v.second.get<std::string>("type"));
-    typedef NodeConfig::Type Type;
-    if (cfg.type == Type::INPUT || cfg.type == Type::INPUT_SEQUENCE) {
-      cfg.index = v.second.get<int>("size");
-    } else if (cfg.type == Type::FEED_FORWARD || cfg.type == Type::SEQUENCE ||
-               cfg.type == Type::TIME_DISTRIBUTED) {
-      cfg.index = v.second.get<int>("layer_index");
-    } else if (layerless_nodes.count(cfg.type)){
-      cfg.index = -1;
-    } else {
-      throw std::logic_error("unknown node type");
-    }
-    return cfg;
-  }
-
-  OutputNodeConfig get_output_node(const ptree::value_type& v) {
-    OutputNodeConfig cfg;
-    for (const auto& lab: v.second.get_child("labels")) {
-      cfg.labels.push_back(lab.second.get_value<std::string>());
-    }
-    int idx = v.second.get<int>("node_index");
-    if (idx < 0) throw std::logic_error("output node index is negative");
-    cfg.node_index = idx;
-    return cfg;
-  }
-
-  NodeConfig::Type get_node_type(const std::string& type) {
-    typedef NodeConfig::Type Type;
-    if (type == "feed_forward") return Type::FEED_FORWARD;
-    if (type == "sequence") return Type::SEQUENCE;
-    if (type == "input") return Type::INPUT;
-    if (type == "input_sequence") return Type::INPUT_SEQUENCE;
-    if (type == "concatenate") return Type::CONCATENATE;
-    if (type == "time_distributed") return Type::TIME_DISTRIBUTED;
-    if (type == "sum") return Type::SUM;
-    throw std::logic_error("no node type '" + type + "'");
-  }
-
-  LayerConfig get_layer(const ptree::value_type& v) {
-    using namespace lwt;
-    LayerConfig layer;
-    set_defaults(layer);
-    Architecture arch = get_architecture(
-      v.second.get<std::string>("architecture"));
-
-    if (arch == Architecture::DENSE) {
-      add_dense_info(layer, v);
-    } else if (arch == Architecture::NORMALIZATION) {
-      add_dense_info(layer, v); // re-use dense layer
-    } else if (arch == Architecture::MAXOUT) {
-      add_maxout_info(layer, v);
-    } else if (arch == Architecture::LSTM ||
-               arch == Architecture::GRU ||
-               arch == Architecture::SIMPLERNN ||
-               arch == Architecture::HIGHWAY) {
-      add_component_info(layer, v);
-    } else if (arch == Architecture::EMBEDDING) {
-      add_embedding_info(layer, v);
-    } else {
-      throw std::logic_error("architecture not implemented");
-    }
-    layer.architecture = arch;
-    return layer;
-  }
-
-  lwt::ActivationConfig get_activation(const ptree& v) {
+  //
+  // ActivationConfig
+  //
+  void from_json(const nlohmann::json& j, ActivationConfig& cfg) {
     // check if this is an "advanced" activation function, in which
     // case it should store the values slightly differently
-    lwt::ActivationConfig cfg;
-    if (v.size() > 0) {
-      cfg.function = get_activation_function(
-        v.get<std::string>("function"));
-      cfg.alpha = v.get<double>("alpha");
+    if (j.type()!=nlohmann::json::value_t::string) {
+      j.at("function").get_to(cfg.function);
+      j.at("alpha").get_to(cfg.alpha);
     } else {
-      cfg.function = get_activation_function(v.data());
+      j.get_to(cfg.function);
       cfg.alpha = NAN;
       // special case: kerasfunc2json converter used to pass through
       // the elu activation function. For cases where this has been
@@ -206,141 +107,158 @@ namespace {
         cfg.alpha = 1.0;
       }
     }
-    return cfg;
   }
 
-  lwt::Activation get_activation_function(const std::string& str) {
-    using namespace lwt;
-    if (str == "linear") return Activation::LINEAR;
-    if (str == "sigmoid") return Activation::SIGMOID;
-    if (str == "rectified") return Activation::RECTIFIED;
-    if (str == "softmax") return Activation::SOFTMAX;
-    if (str == "tanh") return Activation::TANH;
-    if (str == "hard_sigmoid") return Activation::HARD_SIGMOID;
-    if (str == "elu") return Activation::ELU;
-    if (str == "leakyrelu") return Activation::LEAKY_RELU;
-    if (str == "swish") return Activation::SWISH;
-    if (str == "abs") return Activation::ABS;
-    // legacy activations. These use UnaryActivationLayer. Just around
-    // for benchmarks now.
-    if (str == "sigmoid_legacy") return Activation::SIGMOID_LEGACY;
-    if (str == "hard_sigmoid_legacy") return Activation::HARD_SIGMOID_LEGACY;
-    if (str == "tanh_legacy") return Activation::TANH_LEGACY;
-    if (str == "rectified_legacy") return Activation::RECTIFIED_LEGACY;
-    throw std::logic_error("activation function " + str + " not recognized");
-    return Activation::LINEAR;
-  }
+  //
+  // LayerConfig
+  //
+  void from_json(const nlohmann::json& j, LayerConfig& layer) {
 
+    j.at("architecture").get_to(layer.architecture);
 
-  lwt::Architecture get_architecture(const std::string& str) {
-    using namespace lwt;
-    if (str == "dense") return Architecture::DENSE;
-    if (str == "normalization") return Architecture::NORMALIZATION;
-    if (str == "highway") return Architecture::HIGHWAY;
-    if (str == "maxout") return Architecture::MAXOUT;
-    if (str == "lstm") return Architecture::LSTM;
-    if (str == "gru") return Architecture::GRU;
-    if (str == "simplernn") return Architecture::SIMPLERNN;
-    if (str == "embedding") return Architecture::EMBEDDING;
-    throw std::logic_error("architecture " + str + " not recognized");
-  }
-
-  void set_defaults(LayerConfig& layer) {
-    layer.activation.function = Activation::NONE;
-    layer.inner_activation.function = Activation::NONE;
-    layer.architecture = Architecture::NONE;
-  }
-
-  void add_dense_info(LayerConfig& layer, const ptree::value_type& v) {
-    for (const auto& wt: v.second.get_child("weights")) {
-      layer.weights.push_back(wt.second.get_value<double>());
-    }
-    for (const auto& bs: v.second.get_child("bias")) {
-      layer.bias.push_back(bs.second.get_value<double>());
-    }
-    // this last category is currently only used for LSTM
-    if (v.second.count("U") != 0) {
-      for (const auto& wt: v.second.get_child("U") ) {
-        layer.U.push_back(wt.second.get_value<double>());
-      }
-    }
-
-    if (v.second.count("activation") != 0) {
-      layer.activation = get_activation(v.second.get_child("activation"));
-    }
-
-  }
-
-  void add_maxout_info(LayerConfig& layer, const ptree::value_type& v) {
-    using namespace lwt;
-    for (const auto& sub: v.second.get_child("sublayers")) {
-      LayerConfig sublayer;
-      set_defaults(sublayer);
-      add_dense_info(sublayer, sub);
-      layer.sublayers.push_back(sublayer);
+    switch(layer.architecture) {
+    case Architecture::DENSE:
+      add_dense_info(layer, j);
+      break;
+    case Architecture::NORMALIZATION:
+      add_dense_info(layer, j); // re-use dense layer
+      break;
+    case Architecture::MAXOUT:
+      add_maxout_info(layer, j);
+      layer.activation.function = Activation::NONE; // FIXME: to make throw_if_not_maxout() happy
+      break;
+    case Architecture::LSTM:
+    case Architecture::GRU:
+    case Architecture::SIMPLERNN:
+    case Architecture::HIGHWAY:
+      add_component_info(layer, j);
+      break;
+    case Architecture::EMBEDDING:
+      add_embedding_info(layer, j);
+      break;
+    default:
+      throw std::logic_error("architecture not implemented");
     }
   }
 
+  //
+  // NodeConfig
+  //
+  void from_json(const nlohmann::json& j, NodeConfig& cfg) {
 
-  const std::map<std::string, lwt::Component> component_map {
-    {"i", Component::I},
-    {"o", Component::O},
-    {"c", Component::C},
-    {"f", Component::F},
-    {"z", Component::Z},
-    {"r", Component::R},
-    {"h", Component::H},
-    {"t", Component::T},
-    {"carry", Component::CARRY}
-  };
-
-  void add_component_info(LayerConfig& layer, const ptree::value_type& v) {
-    using namespace lwt;
-    for (const auto& comp: v.second.get_child("components")) {
-      LayerConfig cfg;
-      set_defaults(cfg);
-      add_dense_info(cfg, comp);
-      layer.components[component_map.at(comp.first)] = cfg;
+    j.at("sources").get_to(cfg.sources);
+    if (std::any_of(cfg.sources.begin(), cfg.sources.end(), [](int i){return i<0;})) {
+      throw std::logic_error("node source number must be positive");
     }
-    layer.activation = get_activation(v.second.get_child("activation"));
-    if (v.second.count("inner_activation") != 0) {
-      layer.inner_activation = get_activation(
-        v.second.get_child("inner_activation"));
-    }
-  }
+    cfg.type = j.at("type").get<NodeConfig::Type>();
 
-
-  void add_embedding_info(LayerConfig& layer, const ptree::value_type& v) {
-    using namespace lwt;
-    for (const auto& sub: v.second.get_child("sublayers")) {
-      EmbeddingConfig emb;
-      for (const auto& wt: sub.second.get_child("weights")) {
-        emb.weights.push_back(wt.second.get_value<double>());
-      }
-      emb.index = sub.second.get<int>("index");
-      emb.n_out = sub.second.get<int>("n_out");
-      layer.embedding.push_back(emb);
+    switch(cfg.type) {
+    case NodeConfig::Type::INPUT:
+    case NodeConfig::Type::INPUT_SEQUENCE:
+      j.at("size").get_to(cfg.index);
+      break;
+    case NodeConfig::Type::FEED_FORWARD:
+    case NodeConfig::Type::SEQUENCE:
+    case NodeConfig::Type::TIME_DISTRIBUTED:
+      j.at("layer_index").get_to(cfg.index);
+      break;
+    // Layerless nodes
+    case NodeConfig::Type::CONCATENATE:
+    case NodeConfig::Type::SUM:
+      cfg.index = -1;
+      break;
+    default:
+      throw std::logic_error("unknown node type");
     }
   }
 
-  std::map<std::string, double> get_defaults(const ptree& pt) {
-    const std::string dname = "defaults";
-    std::map<std::string, double> defaults;
+  //
+  // JSONConfig
+  //
+  void from_json(const nlohmann::json& j, JSONConfig& cfg) {
+    j.at("inputs").get_to(cfg.inputs);
+    j.at("layers").get_to(cfg.layers);
+    j.at("outputs").get_to(cfg.outputs);
+
     // NOTE: at some point we may deprecate this first way of storing
     // default values.
-    if (pt.count(dname)) {
-      for (const auto& def: pt.get_child(dname)) {
-        defaults.emplace(def.first, def.second.get_value<double>());
-      }
+    if (j.contains("defaults")) {
+      j["defaults"].get_to(cfg.defaults);
     } else {
-      const std::string dkey = "default";
-      for (const auto& v: pt.get_child("inputs")) {
-        if (v.second.count(dkey)) {
-          std::string key = v.second.get<std::string>("name");
-          defaults.emplace(key, v.second.get<double>(dkey));
+      for (const auto& v: j.at("inputs")) {
+        if (v.contains("default")) {
+          cfg.defaults.emplace(v["name"].get<std::string>(),
+                               v["default"].get<double>());
         }
       }
     }
-    return defaults;
+
+    if (j.contains("miscellaneous")) {
+      j["miscellaneous"].get_to(cfg.miscellaneous);
+    }
+  }
+
+  JSONConfig parse_json(std::istream& json)
+  {
+    nlohmann::json j;
+    json >> j;
+    return j.get<JSONConfig>();
+  }
+
+  GraphConfig parse_json_graph(std::istream& json) {
+    nlohmann::json j;
+    json >> j;
+    return j.get<GraphConfig>();
+  }
+}
+
+
+// Internal helpers
+namespace {
+
+  void add_dense_info(LayerConfig& layer, const nlohmann::json& j) {
+    j.at("weights").get_to(layer.weights);
+    j.at("bias").get_to(layer.bias);
+
+    // this last category is currently only used for LSTM
+    if (j.contains("U")) {
+      j["U"].get_to(layer.U);
+    }
+
+    if (j.contains("activation")) {
+      j["activation"].get_to(layer.activation);
+    }
+  }
+
+  void add_maxout_info(LayerConfig& layer, const nlohmann::json& j) {
+    for (const auto& sub: j.at("sublayers")) {
+      LayerConfig sublayer;
+      add_dense_info(sublayer, sub);
+      layer.sublayers.push_back(std::move(sublayer));
+    }
+  }
+
+  void add_component_info(LayerConfig& layer, const nlohmann::json& j) {
+    for (const auto& it : j.at("components").items()) {
+      LayerConfig cfg;
+      add_dense_info(cfg, it.value());
+      Component c;
+      from_json(it.key(), c);
+      layer.components[c] = cfg;
+    }
+    j.at("activation").get_to(layer.activation);
+    if (j.contains("inner_activation")) {
+      j["inner_activation"].get_to(layer.inner_activation);
+    }
+  }
+
+  void add_embedding_info(LayerConfig& layer, const nlohmann::json& j) {
+    for (const auto& sub: j.at("sublayers")) {
+      EmbeddingConfig emb;
+      sub.at("weights").get_to(emb.weights);
+      //emb.index = sub.second.get<int>("index"); FIXME (need an example NN file)
+      //emb.n_out = sub.second.get<int>("n_out"); FIXME
+      layer.embedding.push_back(std::move(emb));
+    }
   }
 }


### PR DESCRIPTION
Migrate the json parser from `boost` to `nlohmann_json`, which provides
a better JSON API, is signifcantly faster and results in much smaller
binaries (up to 30x smaller).

In particular, for an ATLAS electron DNN:
- 4x faster reading of the JSON
- `malloc`s reduced from ~5M to 2k
- 10 times smaller resident memory size

If this is a welcome change, this PR needs a bit more work, i.e. to validate the changes on all possible network configurations. I would need some advice on how to do that (the unit test coverage seems not very good so far, `test-GRU.sh` passes but it does not seem to test all code paths).