### PR TITLE
fix: Use current release tag in tests CMakeLists.txt

### DIFF
--- a/tests/install/CMakeLists.txt
+++ b/tests/install/CMakeLists.txt
@@ -4,6 +4,6 @@ project(TestLwtnn)
 set( CMAKE_CXX_STANDARD 11 CACHE STRING
   "C++ standard to use for the build" )
 
-find_package( lwtnn 2.12 REQUIRED )
+find_package( lwtnn 2.12.1 REQUIRED )
 add_executable(test-lwtnn test-lwtnn.cxx )
 target_link_libraries( test-lwtnn lwtnn::lwtnn )


### PR DESCRIPTION
Update lwtnn package tag used for tests to the current release tag of v2.12.1

Amends 84dcb5e646b631d29ef6830975a3dd7932e2a3be