### PR TITLE
ci: Add Python 3.10 to testing in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
         build-system: ["make", "tests/build-cmake.sh", "STANDARD=17 tests/build-cmake.sh", "STANDARD=20 tests/build-cmake.sh"]
 
     steps:
@@ -59,7 +59,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
CPython 3.10 is out now (:tada:) and this PR adds it to the testing matrix in the CI. The addition of the quotes on the numbers are required as YAML will view `3.10` as `3.1` if not quoted properly. :disappointed: 

---

This PR can be reviewed now but it shouldn't be merged at the moment (2021-10-07) as NumPy does not have Python 3.10 wheels out for [`numpy==1.19.3`](https://pypi.org/project/numpy/1.19.3/#files) and as a result that means that [`h5py` doesn't have Python 3.10 wheels out either](https://pypi.org/project/h5py/3.4.0/#files) given that [`h5py` requires that version during their wheel build](https://github.com/h5py/h5py/blob/4d1dcffd2ec522e45f02dcc12d02f70f3ca47d3d/tox.ini#L24) (following taken from the CI)

```
/opt/hostedtoolcache/Python/3.10.0/x64/bin/python /tmp/pip-standalone-pip-l8j_aatm/__env_pip__.zip/pip install --ignore-installed --no-user --prefix /tmp/pip-build-env-rl3z6hx0/normal --no-warn-script-location --no-binary :none: --only-binary :none: -i https://pypi.org/simple -- 'Cython>=0.29.15; python_version >= "3.9"' 'numpy==1.17.5; python_version == "3.8"' pkgconfig 'numpy==1.14.5; python_version == "3.7"' 'numpy==1.19.3; python_version >= "3.9"' 'Cython>=0.29.14; python_version == "3.8"' 'Cython>=0.29; python_version < "3.8"'
```



The CI is capable of building NumPy wheels, but it takes around 15 minutes to do so and that's not a good use of CI compute or anyone's time.

As soon as h5py releases 3.10 wheels this can get merged though (or if they change the version of NumPy used to do the build as building the rest of `h5py` is not that taxing)

<details>
<summary>Example of building h5py wheels for Python 3.9 in about 1min 30 seconds:</summary>

```console
$ docker run --rm -ti python:3.9 /bin/bash
root@1b5ef0b40086:/# apt update -y && apt install -y libhdf5-serial-dev
...
root@1b5ef0b40086:/# curl -sLO https://files.pythonhosted.org/packages/7b/c5/d71a944e0637a0db5a0f779c6b757253149fec439a5cafd5fc87e277658b/h5py-3.4.0.tar.gz
root@1b5ef0b40086:/# python -m pip install --upgrade pip setuptools wheel
Requirement already satisfied: pip in /usr/local/lib/python3.9/site-packages (21.2.4)
Requirement already satisfied: setuptools in /usr/local/lib/python3.9/site-packages (57.5.0)
Collecting setuptools
  Downloading setuptools-58.2.0-py3-none-any.whl (946 kB)
     |████████████████████████████████| 946 kB 5.6 MB/s 
Requirement already satisfied: wheel in /usr/local/lib/python3.9/site-packages (0.37.0)
Installing collected packages: setuptools
  Attempting uninstall: setuptools
    Found existing installation: setuptools 57.5.0
    Uninstalling setuptools-57.5.0:
      Successfully uninstalled setuptools-57.5.0
Successfully installed setuptools-58.2.0
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
root@1b5ef0b40086:/# #time python -m pip install ./h5py-3.4.0.tar.gz 
root@1b5ef0b40086:/# pip list
Package    Version
---------- -------
pip        21.2.4
setuptools 58.2.0
wheel      0.37.0
root@1b5ef0b40086:/# time python -m pip install ./h5py-3.4.0.tar.gz 
Processing /h5py-3.4.0.tar.gz
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Installing backend dependencies ... done
    Preparing wheel metadata ... done
Collecting numpy>=1.19.3
  Downloading numpy-1.21.2-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl (15.8 MB)
     |████████████████████████████████| 15.8 MB 5.4 MB/s 
Building wheels for collected packages: h5py
  Building wheel for h5py (PEP 517) ... done
  Created wheel for h5py: filename=h5py-3.4.0-cp39-cp39-linux_x86_64.whl size=6565808 sha256=668ec66bedfedeab703aae8b60a1d65e0a720d515eaf15f2937b4d21f6704746
  Stored in directory: /root/.cache/pip/wheels/d2/58/05/3af60ef28437e50233803a6fb56cb8fdc65eb8eb2c0b3ee7fa
Successfully built h5py
Installing collected packages: numpy, h5py
Successfully installed h5py-3.4.0 numpy-1.21.2
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv

real	1m34.096s
user	1m30.165s
sys	0m3.719s
root@1b5ef0b40086:/# pip list
Package    Version
---------- -------
h5py       3.4.0
numpy      1.21.2
pip        21.2.4
setuptools 58.2.0
wheel      0.37.0
root@1b5ef0b40086:/# 
```

</details>