### PR TITLE
ci: Add pre-commit hook to reject tabs and CRLF from files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,8 @@ repos:
 -   repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.1.10
     hooks:
+    - id: forbid-crlf
+    - id: remove-crlf
     - id: forbid-tabs
       exclude: ^makefile
     - id: remove-tabs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,3 +11,11 @@ repos:
       args: [--fix=lf]
     - id: trailing-whitespace
     - id: requirements-txt-fixer
+
+-   repo: https://github.com/Lucas-C/pre-commit-hooks
+    rev: v1.1.10
+    hooks:
+    - id: forbid-tabs
+      exclude: ^makefile
+    - id: remove-tabs
+      exclude: ^makefile

--- a/src/lightweight_nn_streamers.cxx
+++ b/src/lightweight_nn_streamers.cxx
@@ -7,7 +7,7 @@
 
 namespace lwt {
   std::ostream& operator<<(std::ostream& out,
-			   const std::vector<double>& vec) {
+                          const std::vector<double>& vec) {
     std::size_t nentry = vec.size();
     for (std::size_t iii = 0; iii < nentry; iii++) {
       out << vec.at(iii);

--- a/src/lightweight_nn_streamers.cxx
+++ b/src/lightweight_nn_streamers.cxx
@@ -7,7 +7,7 @@
 
 namespace lwt {
   std::ostream& operator<<(std::ostream& out,
-                          const std::vector<double>& vec) {
+               const std::vector<double>& vec) {
     std::size_t nentry = vec.size();
     for (std::size_t iii = 0; iii < nentry; iii++) {
       out << vec.at(iii);


### PR DESCRIPTION
Add and apply a pre-commit hook that enforces spaces over tabs. Additionally also enable the CRLF rejection.

Tabs are replaced with 4 spaces by default
```diff
$ git diff origin/master -- src/
diff --git a/src/lightweight_nn_streamers.cxx b/src/lightweight_nn_streamers.cxx
index 7933b7e..02f3bc0 100644
--- a/src/lightweight_nn_streamers.cxx
+++ b/src/lightweight_nn_streamers.cxx
@@ -7,7 +7,7 @@
 
 namespace lwt {
   std::ostream& operator<<(std::ostream& out,
-                          const std::vector<double>& vec) {
+               const std::vector<double>& vec) {
     std::size_t nentry = vec.size();
     for (std::size_t iii = 0; iii < nentry; iii++) {
       out << vec.at(iii);
```


**Suggested squash and merge commit message**:
```
* Add and apply Lucas-C/pre-commit-hooks to pre-commit hooks
   - Forbids the use of CRLF and tabs in all files
   - Tabs are replaced with 4 spaces
   - Ignores Makefile as tabs are necessary
```