### PR TITLE
test:  Remove lwtnn version in tests find_package to ensure latest

### DIFF
--- a/tests/install/CMakeLists.txt
+++ b/tests/install/CMakeLists.txt
@@ -4,6 +4,6 @@ project(TestLwtnn)
 set( CMAKE_CXX_STANDARD 11 CACHE STRING
   "C++ standard to use for the build" )
 
-find_package( lwtnn 2.12.1 REQUIRED )
+find_package( lwtnn REQUIRED )
 add_executable(test-lwtnn test-lwtnn.cxx )
 target_link_libraries( test-lwtnn lwtnn::lwtnn )


### PR DESCRIPTION
~~This PR updates the test version installed to `v2.13` to ensure the latest version is being tested.~~

This PR removes the specification of the test version, which should safely pick up the latest version for testing.