### PR TITLE
docs: Update Matthew's affiliation to University of Wisconsin-Madison

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -41,7 +41,7 @@
         },
         {
             "name": "Matthew Feickert",
-            "affiliation": "University of Illinois at Urbana-Champaign",
+            "affiliation": "University of Wisconsin-Madison",
             "orcid": "0000-0003-4124-7862"
         }
     ]


### PR DESCRIPTION
@matthewfeickert is a postdoc at University of Wisconsin-Madison as of June 2022.