### PR TITLE
chore: Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
+    rev: v4.3.0
     hooks:
     - id: check-case-conflict
     - id: check-merge-conflict
@@ -13,7 +13,7 @@ repos:
     - id: requirements-txt-fixer
 
 -   repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.1.13
+    rev: v1.3.1
     hooks:
     - id: forbid-crlf
     - id: remove-crlf


### PR DESCRIPTION
* github.com/pre-commit/pre-commit-hooks: v4.2.0 → v4.3.0
* github.com/Lucas-C/pre-commit-hooks: v1.1.13 → v1.3.1