### PR TITLE
Fix for tensorflow api changes

### DIFF
--- a/scripts/lwtnn-test-keras-functional.py
+++ b/scripts/lwtnn-test-keras-functional.py
@@ -28,7 +28,10 @@ def run():
     # keras loads slow, do the loading here
     from keras.models import model_from_json
     from CustomLayers import Swish, Sum
-    from keras.utils.generic_utils import get_custom_objects
+    try:
+        from keras.utils.generic_utils import get_custom_objects
+    except ImportError:
+        from tensorflow.keras.utils import get_custom_objects
     get_custom_objects().update({'Swish': Swish, 'Sum': Sum})
 
     with open(args.archetecture_file) as arch:


### PR DESCRIPTION
In my current version of tensorflow and keras (both 2.11.0) `get_custom_objects` has moved. As a fallback, I take the function directly from tensorflow instead when the original import fails.

In most of the code in this repository I've avoided importing `keras` or `tensorflow`, since the internals are pretty unstable. We usually just pull apart the saved model files directly. This and a few other scripts are exceptions, though. At some point I should go through and make sure they all work using `tensorflow.keras`, since the stand-alone `keras` project isn't as widely used these days.