### PR TITLE
Don't overwrite CMAKE_CXX_FLAGS, add to them

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,8 @@ endif()
 message( STATUS "Using build type: ${CMAKE_BUILD_TYPE}" )
 
 # Set the warning flag(s) to use.
-set( CMAKE_CXX_FLAGS "-Wall -pedantic -Wextra -Wcomment -Wunused-value" )
+set( CMAKE_CXX_FLAGS
+   "${CMAKE_CXX_FLAGS} -Wall -pedantic -Wextra -Wcomment -Wunused-value" )
 
 # Turn off the usage of RPATH completely:
 set( CMAKE_SKIP_RPATH ON )


### PR DESCRIPTION
This is a fix in response to a problem that @krasznaa reported in [an internal ATLAS JIRA ticket](https://its.cern.ch/jira/browse/ATEAM-905).

Apparently overwriting the `CMAKE_CXX_FLAGS` here was causing all kinds of problems.