### PR TITLE
chore: Allow for CMake policy_max of 4.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 # Set range of valid CMake versions to build the project.
-cmake_minimum_required(VERSION 3.1...3.20)
+cmake_minimum_required(VERSION 3.1...4.2)
 
 if(${CMAKE_VERSION} VERSION_LESS 3.12)
     cmake_policy(VERSION ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION})

--- a/tests/install/CMakeLists.txt
+++ b/tests/install/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12...3.20)
+cmake_minimum_required(VERSION 3.12...4.2)
 project(TestLwtnn)
 
 set( CMAKE_CXX_STANDARD 11 CACHE STRING


### PR DESCRIPTION
* CMake v4 is out as of 2025 and extending the policy_max makes builds more accessible across CMake releases.
* As this allows for CMake policies up to 4.2, this also addresses warnings for CMake policy CMP0167, which was added in CMake v3.30.
   - c.f. https://cmake.org/cmake/help/latest/policy/CMP0167.html
---

* Compilation at 60c14975e5dd2f17f7f28cc75ce1c0267d0eb456 with modern CMake raises

```
CMake Warning (dev) at CMakeLists.txt:82 (find_package):
  Policy CMP0167 is not set: The FindBoost module is removed.  Run "cmake
  --help-policy CMP0167" for policy details.  Use the cmake_policy command to
  set the policy and suppress this warning.

This warning is for project developers.  Use -Wno-dev to suppress it.
```

* This PR raises no warnings.