### PR TITLE
ci: Test against non-EOL Pythons

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         build-system: ["make", "tests/build-cmake.sh", "STANDARD=17 tests/build-cmake.sh", "STANDARD=20 tests/build-cmake.sh"]
 
     steps:
@@ -44,7 +44,7 @@ jobs:
         cmake --version
     - name: Install Python dependencies
       run: |
-        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --upgrade pip
         python -m pip install --requirement tests/requirements.txt
         python -m pip list
     - name: Build
@@ -59,7 +59,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - uses: actions/checkout@v3
@@ -78,7 +78,7 @@ jobs:
         libhdf5-serial-dev
     - name: Install Python dependencies
       run: |
-        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --upgrade pip
         python -m pip install --requirement tests/requirements.txt
         python -m pip list
     - name: Build


### PR DESCRIPTION
* Python 3.9 went EOL on 2025-10-31, so test from Python 3.10 to Python 3.14.
   - Also, the `actions/setup-python` GHA won't set up older Pythons anymore as GitHub has dropped those.
* setuptools and wheel are only needed if building is happening and the build backend is setuptools. Neither is happening in the tests, so these can be removed.