### PR TITLE
docs: Add conda-forge install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ very useful.
 Getting the code
 ----------------
 
+### From source
+
 Clone the project from github:
 
 ```bash
@@ -74,6 +76,24 @@ If you have CMake, you can build with _no_ other dependencies:
 ```bash
 cmake -DBUILTIN_BOOST=true -DBUILTIN_EIGEN=true -S . -B build
 cmake --build build --parallel 4
+```
+
+### From conda-forge
+
+lwtnn is available as a conda package [on conda-forge](https://github.com/conda-forge/lwtnn-feedstock) for the following platforms:
+
+[![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/lwtnn.svg)](https://anaconda.org/conda-forge/lwtnn)
+
+The lwtnn conda package can be installed into a particular project with [Pixi](https://pixi.sh/)
+
+```
+pixi add lwtnn
+```
+
+or into a conda environment with [conda](https://docs.conda.io/projects/conda/)
+
+```
+conda install --channel conda-forge lwtnn
 ```
 
 Running a full-chain test

--- a/README.md
+++ b/README.md
@@ -72,10 +72,8 @@ version of Eigen and Boost everything should work without errors.
 If you have CMake, you can build with _no_ other dependencies:
 
 ```bash
-mkdir build
-cd build
-cmake -DBUILTIN_BOOST=true -DBUILTIN_EIGEN=true ..
-make -j 4
+cmake -DBUILTIN_BOOST=true -DBUILTIN_EIGEN=true -S . -B build
+cmake --build build --parallel 4
 ```
 
 Running a full-chain test


### PR DESCRIPTION
Resolves #186 

* Use CMake's source and build directory definition syntax to avoid unnecessary directory movement.
* Use 'cmake --build' syntax over explicit use of 'make' to use more portable patterns if alternative build systems, like Ninja, are used.

**Example:** The following works
```
cmake -G Ninja -DCMAKE_INSTALL_PREFIX=<path to install target> -S . -B build
cmake build -LH
cmake --build build --clean-first --parallel "$(nproc --ignore=2)"
cmake --install build
```

* Add instructions to the README on how to install the lwtnn conda package from conda-forge.
   - c.f. https://github.com/conda-forge/lwtnn-feedstock
