### PR TITLE
Fix MSVC-incompatible warning flags in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,8 @@ if( BUILTIN_EIGEN )
       URL "https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.tar.bz2"
       URL_MD5 "b9e98a200d2455f06db9c661c5610496"
       DOWNLOAD_NAME "eigen-3.3.7.tar.bz2"
-      CMAKE_CACHE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR> )
+      CMAKE_CACHE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
+                       -DCMAKE_POLICY_VERSION_MINIMUM:STRING=3.5 )
    # The eigen headers are needed by clients of this project as well, so let's
    # install them with the project.
    install( DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/externals/Eigen/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ project( lwtnn VERSION 2.14.2 )
 # Enable using CTest in the project.
 include( CTest )
 
-# Set up the "C++ version" to use.
+# Set up the C++ version to use.
 set( CMAKE_CXX_STANDARD_REQUIRED 11 CACHE STRING
    "Minimum C++ standard required for the build" )
 set( CMAKE_CXX_STANDARD 11 CACHE STRING

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,9 +32,14 @@ if( "${CMAKE_BUILD_TYPE}" STREQUAL "" )
 endif()
 message( STATUS "Using build type: ${CMAKE_BUILD_TYPE}" )
 
-# Set the warning flag(s) to use.
-set( CMAKE_CXX_FLAGS
-   "${CMAKE_CXX_FLAGS} -Wall -pedantic -Wextra -Wcomment -Wunused-value" )
+# Set compiler-specific warning flag(s).
+if( MSVC )
+   set( CMAKE_CXX_FLAGS
+      "${CMAKE_CXX_FLAGS} /W3" )
+else()
+   set( CMAKE_CXX_FLAGS
+      "${CMAKE_CXX_FLAGS} -Wall -pedantic -Wextra -Wcomment -Wunused-value" )
+endif()
 
 # Turn off the usage of RPATH completely:
 set( CMAKE_SKIP_RPATH ON )


### PR DESCRIPTION
This PR makes the warning flags in CMakeLists.txt compiler-specific. Currently, GCC/Clang-style flags (-Wall -Wextra ...) are applied unconditionally via CMAKE_CXX_FLAGS. On MSVC this leads to build failures, e.g.:

cl : command line error D8021: invalid numeric argument '/Wextra'

Now the flags are conditioned with a compiler check that uses /W3 for MSVC and keeps existing flags for non-MSVC compilers.